### PR TITLE
[th/ocp-tft-image-update] github: update tft-test-image container URL after migration

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,10 +21,6 @@ jobs:
       run: |
         docker buildx create --use
 
-    - name: Convert GitHub repository owner to lowercase
-      id: lowercase_owner
-      run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
     - name: Log in to GitHub Container Registry
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -34,6 +30,6 @@ jobs:
         docker buildx build \
           --file ./Containerfile \
           --platform linux/arm64,linux/amd64 \
-          --tag ghcr.io/${{ env.owner }}/ocp-traffic-flow-tests:latest \
+          --tag ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest \
           --push \
           .

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Simply run the python application as so:
 
 ## Environment variables
 
-- `TFT_TEST_IMAGE` specify the test image. Defaults to `ghcr.io/wizhaoredhat/ocp-traffic-flow-tests:latest`.
+- `TFT_TEST_IMAGE` specify the test image. Defaults to `ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest`.
      This is mainly for development and manual testing, to inject another container image.
 - `TFT_IMAGE_PULL_POLICY` the image pull policy. One of `IfNotPresent`, `Always`, `Never`.
      Defaults to `IfNotPresent`m unless `$TFT_TEST_IMAGE` is set (in which case it defaults

--- a/tftbase.py
+++ b/tftbase.py
@@ -24,7 +24,9 @@ logger = logging.getLogger("tft." + __name__)
 ENV_TFT_TEST_IMAGE = "TFT_TEST_IMAGE"
 ENV_TFT_IMAGE_PULL_POLICY = "TFT_IMAGE_PULL_POLICY"
 
-ENV_TFT_TEST_IMAGE_DEFAULT = "ghcr.io/wizhaoredhat/ocp-traffic-flow-tests:latest"
+ENV_TFT_TEST_IMAGE_DEFAULT = (
+    "ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest"
+)
 
 
 def get_environ(name: str) -> Optional[str]:


### PR DESCRIPTION
The repository migrated, so the tag/URL of the container needs to be adjusted.

Also, in the github workflow don't detect the "owner" via a separate build step. Other places in the repository also hard code the actual URL, so if we ever move it again, we anyway have to update those places. Having the owner part detected makes it harder to understand which tag will be used.

---

I didn't actually test this, because the image will only be rebuild when the patch gets merged to `main`. Please extra careful review.