### PR TITLE
[th/ocp-secondary-nad] testConfig: change the default for "secondary_network_nad" from "ocp-secondary" to "tft-secondary"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ kubeconfig_infra: (18)
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
-16. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-29, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-29 it defaults to "ocp-secondary" if not set.
+16. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-29, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-29 it defaults to "tft-secondary" if not set.
 17. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test
 tool will try to autopopulate resource_name based on the secondary+network_nad provided.
 18. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ tft:
           - name: measure_cpu
           - name: measure_power
           - name: validate_offload
-        # (Optional) Secondary network is required for tests 27-29. For these tests, it is mandatory; if not specified, it will default to "ocp-secondary." For other tests, 
+        # (Optional) Secondary network is required for tests 27-29. For these tests, it is mandatory; if not specified, it will default to "tft-secondary." For other tests, 
         # the secondary network is optional. If it is undefined, the tests will default to using the primary network.
         # (Optional) Define the resource name for SRIOV pods, where the resource requests and limits are configured. Defaults to None if not set. If the user specified the secondary nad 
         # it will try to autopopulate the resource name based on the nad. 

--- a/testConfig.py
+++ b/testConfig.py
@@ -260,7 +260,7 @@ class ConfConnection(StructParseBaseNamed):
     def effective_secondary_network_nad(self) -> str:
         nad = self.secondary_network_nad
         if nad is None:
-            nad = "ocp-secondary"
+            nad = "tft-secondary"
         if "/" not in nad:
             nad = f"{self.namespace}/{nad}"
         return nad


### PR DESCRIPTION
The project was renamed from "ocp-traffic-flow-tests" to "kubernetes-traffic-flow-tests". Adjust names related to OCP.

The default for "secondary_network_nad" was "ocp-secondary", but only for the test cases POD_TO_POD_2ND_INTERFACE_SAME_NODE (27), POD_TO_POD_2ND_INTERFACE_DIFF_NODE (28) and
POD_TO_POD_MULTI_NETWORK_POLICY (29). For other test cases an unspecified "secondary_network_nad" setting means to use the primary instead.

Update the default. This can break users that run tests 27-29 and don't explicitly configure a "secondary_network_nad" setting. Sorry about that. Please update your configuration.