### PR TITLE
[th/ktoolbox-update] ktoolbox: bump to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ PyYAML
 jc
 jinja2
 paramiko
-git+https://github.com/thom311/ktoolbox@3159f67841efc1ee5b7d82c1173218326f3ef380
+git+https://github.com/thom311/ktoolbox@95c355a54daca6387ef94b6d9412a9c3047e2f2d


### PR DESCRIPTION
There isn't a relevant change there. This is only to sync the used version with the latest available version.