### PR TITLE
[th/kubeconfig-system-check] improve validation of kubeconfig files and add system_check()

### DIFF
--- a/testConfig.py
+++ b/testConfig.py
@@ -567,7 +567,7 @@ class TestConfig:
     kubeconfig_infra: Optional[str]
     _client_tenant: Optional[K8sClient]
     _client_infra: Optional[K8sClient]
-    _client_lock: threading.Lock
+    _lock: threading.Lock
     evaluator_config: Optional[str]
     output_base: Optional[str]
 
@@ -655,7 +655,7 @@ class TestConfig:
         self.cwddir = cwddir
         self.configpath = config_path
 
-        self._client_lock = threading.Lock()
+        self._lock = threading.Lock()
         self._client_tenant = None
         self._client_infra = None
 
@@ -699,7 +699,7 @@ class TestConfig:
         logger.debug(f"config-full: {self.config.serialize_json()}")
 
     def client(self, *, tenant: bool) -> K8sClient:
-        with self._client_lock:
+        with self._lock:
             if tenant:
                 client = self._client_tenant
             else:

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -180,6 +180,7 @@ kubeconfig_infra: /path/to/kubeconfig_infra
 
     assert tc.config.kubeconfig == "/path/to/kubeconfig"
     assert tc.config.kubeconfig_infra == "/path/to/kubeconfig_infra"
+    assert tc._kubeconfig_pair == (tc.config.kubeconfig, tc.config.kubeconfig_infra)
     assert tc.kubeconfig == tc.config.kubeconfig
     assert tc.kubeconfig_infra == tc.config.kubeconfig_infra
 

--- a/tft.py
+++ b/tft.py
@@ -69,6 +69,8 @@ def main() -> None:
         evaluator_config=args.evaluator_config,
         output_base=args.output_base,
     )
+    tc.system_check()
+    tc.log_config()
     tft = TrafficFlowTests()
 
     evaluator = Evaluator(tc.evaluator_config)


### PR DESCRIPTION
The kubeconfig files can be part of the configuration YAML. Or they can be detected defaults based on the files we have on the file system. Also, they can be invalid (e.g. not valid YAML).o

Improve the validation of those files, so that we fail early and with a better error message.

Also, validating the files (and resolving the default values) requires to look at the file system. We want to have a first step (the `TestConfig()` constructor) that only parses and validates the configuration file alone. Only a second step would perform further validation (and check the kubeconfig files on disk). Add a `TestConfig.system_check()` for that purpose.

Benefits:

- better error message for invalid kubeconfig (and at a early stage)
- make `TestConfig()` usable to only validate the configuration file, while having `TestConfig.system_check()` to validate further dependencies (e.g. files on disk). With this, we can validate only configuration alone.