### PR TITLE
Remove workaround for resource limits and requests in sriov pod yaml

### DIFF
--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -17,9 +17,4 @@ spec:
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}
-    imagePullPolicy: {{ image_pull_policy }} {% if use_secondary_network and resource_name %}
-    resources:
-      requests:
-        {{ resource_name }}: '1'
-      limits:
-        {{ resource_name }}: '1' {% endif %}
+    imagePullPolicy: {{ image_pull_policy }}


### PR DESCRIPTION
The reason for this change is that when the PR for enabling the SRIOV dp admission controller goes in, the resource requests and limits should be injected automatically without specification in the yaml. Therefore these traffic flow tests need to be updated to reflect that change.