### PR TITLE
[th/manifests-yamls] improve handling manifests/yamls directory for rendering YAMLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ Simply run the python application as so:
 - `TFT_MANIFESTS_OVERRIDE` to specify an overrides directory for manifests. If not set, the
      default is "manifests/overrides". If set to empty, no overrides are used. You can place
      your own variants of the files from "manifests" directory and they will be preferred.
+- `TFT_MANIFESTS_YAMLS` to specify the output directory for rendered manifests. This
+     defaults to "manifests/yamls".

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -53,8 +53,8 @@ class TaskMeasureCPU(PluginTask):
         )
 
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = (
-            f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"
+        self.out_file_yaml = tftbase.get_manifest_renderpath(
+            f"tools-pod-{self.node_name}-measure-cpu.yaml"
         )
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
 

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -64,8 +64,8 @@ class TaskMeasurePower(PluginTask):
         )
 
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = (
-            f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"
+        self.out_file_yaml = tftbase.get_manifest_renderpath(
+            f"tools-pod-{self.node_name}-measure-cpu.yaml"
         )
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
 

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -158,8 +158,8 @@ class TaskValidateOffload(PluginTask):
         )
 
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = (
-            f"./manifests/yamls/tools-pod-{self.node_name}-validate-offload.yaml"
+        self.out_file_yaml = tftbase.get_manifest_renderpath(
+            f"tools-pod-{self.node_name}-validate-offload.yaml"
         )
         self.pod_name = f"tools-pod-{self.node_name}-validate-offload"
         self._perf_instance = perf_instance

--- a/task.py
+++ b/task.py
@@ -480,7 +480,7 @@ class Task(ABC):
 
     def create_cluster_ip_service(self) -> str:
         in_file_template = tftbase.get_manifest("svc-cluster-ip.yaml.j2")
-        out_file_yaml = "./manifests/yamls/svc-cluster-ip.yaml"
+        out_file_yaml = tftbase.get_manifest_renderpath("svc-cluster-ip.yaml")
 
         self.render_file("Cluster IP Service", in_file_template, out_file_yaml)
         self.run_oc(
@@ -495,7 +495,7 @@ class Task(ABC):
 
     def create_node_port_service(self, nodeport: int) -> str:
         in_file_template = tftbase.get_manifest("svc-node-port.yaml.j2")
-        out_file_yaml = "./manifests/yamls/svc-node-port.yaml"
+        out_file_yaml = tftbase.get_manifest_renderpath("svc-node-port.yaml")
 
         template_args = {
             **self.get_template_args(),
@@ -517,7 +517,7 @@ class Task(ABC):
 
     def create_ingress_multi_network_policy(self, ingressPort: int) -> str:
         in_file_template = tftbase.get_manifest("allow-ingress-mnp.yaml.j2")
-        out_file_yaml = "./manifests/yamls/allow-ingress-mnp.yaml"
+        out_file_yaml = tftbase.get_manifest_renderpath("allow-ingress-mnp.yaml")
 
         template_args = {
             **self.get_template_args(),
@@ -542,7 +542,7 @@ class Task(ABC):
 
     def create_egress_multi_network_policy(self, egressPort: int) -> str:
         in_file_template = tftbase.get_manifest("allow-egress-mnp.yaml.j2")
-        out_file_yaml = "./manifests/yamls/allow-egress-mnp.yaml"
+        out_file_yaml = tftbase.get_manifest_renderpath("allow-egress-mnp.yaml")
 
         template_args = {
             **self.get_template_args(),
@@ -742,21 +742,27 @@ class ServerTask(Task, ABC):
             ConnectionMode.MULTI_NETWORK,
         ):
             in_file_template = tftbase.get_manifest("pod-secondary-network.yaml.j2")
-            out_file_yaml = (
-                f"./manifests/yamls/pod-secondary-network-{node_name}-server.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"pod-secondary-network-{node_name}-server.yaml"
             )
             pod_name = f"normal-pod-secondary-network-{node_name}-server-{port}"
         elif pod_type == PodType.SRIOV:
             in_file_template = tftbase.get_manifest("sriov-pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/sriov-pod-{node_name}-server.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"sriov-pod-{node_name}-server.yaml"
+            )
             pod_name = f"sriov-pod-{node_name}-server-{port}"
         elif pod_type == PodType.NORMAL:
             in_file_template = tftbase.get_manifest("pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/pod-{node_name}-server.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"pod-{node_name}-server.yaml"
+            )
             pod_name = f"normal-pod-{node_name}-server-{port}"
         elif pod_type == PodType.HOSTBACKED:
             in_file_template = tftbase.get_manifest("host-pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/host-pod-{node_name}-server.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"host-pod-{node_name}-server.yaml"
+            )
             pod_name = f"host-pod-{node_name}-server-{port}"
         else:
             raise ValueError("Invalid pod_type {pod_type}")
@@ -899,21 +905,27 @@ class ClientTask(Task, ABC):
 
         if connection_mode in (ConnectionMode.MULTI_HOME, ConnectionMode.MULTI_NETWORK):
             in_file_template = tftbase.get_manifest("pod-secondary-network.yaml.j2")
-            out_file_yaml = (
-                f"./manifests/yamls/pod-secondary-network-{node_name}-client.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"pod-secondary-network-{node_name}-client.yaml"
             )
             pod_name = f"normal-pod-secondary-network-{node_name}-client-{port}"
         elif pod_type == PodType.SRIOV:
             in_file_template = tftbase.get_manifest("sriov-pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/sriov-pod-{node_name}-client.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"sriov-pod-{node_name}-client.yaml"
+            )
             pod_name = f"sriov-pod-{node_name}-client-{port}"
         elif pod_type == PodType.NORMAL:
             in_file_template = tftbase.get_manifest("pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/pod-{node_name}-client.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"pod-{node_name}-client.yaml"
+            )
             pod_name = f"normal-pod-{node_name}-client-{port}"
         elif pod_type == PodType.HOSTBACKED:
             in_file_template = tftbase.get_manifest("host-pod.yaml.j2")
-            out_file_yaml = f"./manifests/yamls/host-pod-{node_name}-client.yaml"
+            out_file_yaml = tftbase.get_manifest_renderpath(
+                f"host-pod-{node_name}-client.yaml"
+            )
             pod_name = f"host-pod-{node_name}-client-{port}"
         else:
             raise ValueError("Invalid pod_type {pod_type}")

--- a/tftbase.py
+++ b/tftbase.py
@@ -29,6 +29,7 @@ ENV_TFT_TEST_IMAGE_DEFAULT = (
 )
 
 ENV_TFT_MANIFESTS_OVERRIDES = "TFT_MANIFESTS_OVERRIDES"
+ENV_TFT_MANIFESTS_YAMLS = "TFT_MANIFESTS_YAMLS"
 
 
 def get_environ(name: str) -> Optional[str]:
@@ -86,6 +87,23 @@ def get_tft_manifests_overrides() -> Optional[str]:
     return path
 
 
+@functools.cache
+def get_tft_manifests_yamls() -> str:
+    d = get_environ(ENV_TFT_MANIFESTS_YAMLS)
+    if d:
+        path = common.path_norm(d, cwd=cwd)
+    else:
+        path = tftfile("manifests/yamls")
+
+    if not os.path.isdir(path):
+        raise RuntimeError(
+            f"{ENV_TFT_MANIFESTS_YAMLS} output directory {shlex.quote(path)} does not exist"
+        )
+
+    logger.info(f"env: {ENV_TFT_MANIFESTS_YAMLS}={shlex.quote(path)}")
+    return path
+
+
 TFT_TESTS = "tft-tests"
 
 
@@ -119,6 +137,11 @@ def get_manifest(filename: str) -> str:
     raise ValueError(
         f"Could not find manifest file {repr(filename)}. Checked in {msg}{repr(f2)}."
     )
+
+
+@functools.cache
+def get_manifest_renderpath(filename: str) -> str:
+    return common.path_norm(get_tft_manifests_yamls() + "/" + filename)
 
 
 def eval_binary_opt_in(

--- a/tftbase.py
+++ b/tftbase.py
@@ -69,6 +69,23 @@ def get_tft_image_pull_policy() -> str:
     return s
 
 
+@functools.cache
+def get_tft_manifests_overrides() -> Optional[str]:
+    d = get_environ(ENV_TFT_MANIFESTS_OVERRIDES)
+    if d:
+        path = common.path_norm(d, cwd=cwd)
+    elif d == "":
+        path = None
+    else:
+        path = tftfile("manifests/overrides")
+
+    # We don't check whether the overrides directory exist. Since the
+    # individual overrides files are optional, so is the entire directory.
+
+    logger.info(f"env: {ENV_TFT_MANIFESTS_OVERRIDES}={shlex.quote(path or '')}")
+    return path
+
+
 TFT_TESTS = "tft-tests"
 
 
@@ -86,24 +103,9 @@ def tftfile(*components: str) -> str:
 
 
 @functools.cache
-def get_manifests_overrides() -> Optional[str]:
-    d = get_environ(ENV_TFT_MANIFESTS_OVERRIDES)
-    if d:
-        d2 = common.path_norm(d, cwd=cwd)
-        if not os.path.isdir(d2):
-            raise ValueError(
-                "Manifest overrides directory {repr(d2)} ({ENV_TFT_MANIFESTS_OVERRIDES}={shlex.quote(d)}) does not exist"
-            )
-        return d2
-    if d == "":
-        return None
-    return tftfile("manifests/overrides")
-
-
-@functools.cache
 def get_manifest(filename: str) -> str:
     assert ".." not in filename.split("/")
-    overrides = get_manifests_overrides()
+    overrides = get_tft_manifests_overrides()
     if overrides is not None:
         f1 = common.path_norm(overrides + "/" + filename, cwd=cwd)
         if os.path.exists(f1):

--- a/tftbase.py
+++ b/tftbase.py
@@ -89,14 +89,14 @@ def tftfile(*components: str) -> str:
 def get_manifests_overrides() -> Optional[str]:
     d = get_environ(ENV_TFT_MANIFESTS_OVERRIDES)
     if d:
-        if d == "":
-            return None
         d2 = common.path_norm(d, cwd=cwd)
         if not os.path.isdir(d2):
             raise ValueError(
-                "Manifest overrides directory {repr(d2)} ({ENV_TFT_TEST_IMAGE}={shlex.quote(d)}) does not exist"
+                "Manifest overrides directory {repr(d2)} ({ENV_TFT_MANIFESTS_OVERRIDES}={shlex.quote(d)}) does not exist"
             )
         return d2
+    if d == "":
+        return None
     return tftfile("manifests/overrides")
 
 


### PR DESCRIPTION
- fix handling empty `TFT_MANIFESTS_OVERRIDES=`.
- cleanup `get_tft_manifests_overrides()` and log value
- improve handling of "manifests/yamls" output to not rely on current working directory.
- make "manifests/yamls" directory configurable via `$TFT_MANIFESTS_YAMLS`