### PR TITLE
[th/aggregate-result-cleanup] cleanup Task.aggregate_output()

### DIFF
--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -125,9 +125,8 @@ class TaskMeasureCPU(PluginTask):
     def _aggregate_output(
         self,
         result: tftbase.AggregatableOutput,
-        tft_result_builder: tftbase.TftResultBuilder,
     ) -> None:
-        result = tft_result_builder.add_plugin(result)
+        assert isinstance(result, PluginOutput)
         if not result.success:
             return
         p_idle = result.result["percent_idle"]

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -122,12 +122,10 @@ class TaskMeasureCPU(PluginTask):
             thread_action=_thread_action,
         )
 
-    def _aggregate_output(
+    def _aggregate_output_log_success(
         self,
         result: tftbase.AggregatableOutput,
     ) -> None:
         assert isinstance(result, PluginOutput)
-        if not result.success:
-            return
         p_idle = result.result["percent_idle"]
         logger.info(f"Idle on {self.node_name} = {p_idle}%")

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -127,7 +127,6 @@ class TaskMeasurePower(PluginTask):
     def _aggregate_output(
         self,
         result: tftbase.AggregatableOutput,
-        tft_result_builder: tftbase.TftResultBuilder,
     ) -> None:
-        result = tft_result_builder.add_plugin(result)
+        assert isinstance(result, PluginOutput)
         logger.info(f"measurePower results: {result.result['measure_power']}")

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -124,7 +124,7 @@ class TaskMeasurePower(PluginTask):
             thread_action=_thread_action,
         )
 
-    def _aggregate_output(
+    def _aggregate_output_log_success(
         self,
         result: tftbase.AggregatableOutput,
     ) -> None:

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -275,9 +275,8 @@ class TaskValidateOffload(PluginTask):
     def _aggregate_output(
         self,
         result: tftbase.AggregatableOutput,
-        tft_result_builder: tftbase.TftResultBuilder,
     ) -> None:
-        result = tft_result_builder.add_plugin(result)
+        assert isinstance(result, PluginOutput)
 
         if self.perf_pod_type == PodType.HOSTBACKED:
             if isinstance(self._perf_instance, task.ClientTask):

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -272,7 +272,7 @@ class TaskValidateOffload(PluginTask):
             thread_action=_thread_action,
         )
 
-    def _aggregate_output(
+    def _aggregate_output_log_success(
         self,
         result: tftbase.AggregatableOutput,
     ) -> None:

--- a/task.py
+++ b/task.py
@@ -33,6 +33,7 @@ from testSettings import TestSettings
 from tftbase import BaseOutput
 from tftbase import ClusterMode
 from tftbase import ConnectionMode
+from tftbase import PluginOutput
 from tftbase import PodType
 from tftbase import TaskRole
 
@@ -638,13 +639,14 @@ class Task(ABC):
                 # fine for a task that returned the FlowTestOutput. Don't call
                 # _aggregate_output.
                 return
+        elif isinstance(result, PluginOutput):
+            tft_result_builder.add_plugin(result)
 
-        self._aggregate_output(result, tft_result_builder)
+        self._aggregate_output(result)
 
     def _aggregate_output(
         self,
         result: tftbase.AggregatableOutput,
-        tft_result_builder: tftbase.TftResultBuilder,
     ) -> None:
         # This should never happen.
         #

--- a/task.py
+++ b/task.py
@@ -633,31 +633,19 @@ class Task(ABC):
                 log_msg = "failure"
             logger.log(log_level, f"Results of {self.ts.get_test_str()}: {log_msg}")
             logger.debug(f"result: {common.dataclass_to_json(result)}")
-
-            if type(self)._aggregate_output is Task._aggregate_output:
-                # This instance did not overwrite _aggregate_output(). This is
-                # fine for a task that returned the FlowTestOutput. Don't call
-                # _aggregate_output.
-                return
         elif isinstance(result, PluginOutput):
             tft_result_builder.add_plugin(result)
 
-        self._aggregate_output(result)
+        if not result.success:
+            logger.warn(f"Result of {type(self).__name__} failed: {result.eval_msg}")
+        else:
+            self._aggregate_output_log_success(result)
 
-    def _aggregate_output(
+    def _aggregate_output_log_success(
         self,
         result: tftbase.AggregatableOutput,
     ) -> None:
-        # This should never happen.
-        #
-        # A task that returns an AggregatableOutput *must* implement _aggregate_output().
-        #
-        # Exception: if the task is a test and returns a flow_test, then it may
-        # not override this method. aggregate_output() will take care to not
-        # call in that case.
-        raise RuntimeError(
-            f"Task {self.log_name} should not be called to aggregate output {result} "
-        )
+        logger.info(f"Result of {type(self).__name__} is success")
 
     def pod_get_device_infos(
         self,

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -103,31 +103,31 @@ class IperfClient(task.ClientTask):
             r = self.run_oc_exec(cmd)
             self.ts.event_client_finished.set()
 
-            parsed_data: dict[str, Any] = {}
+            result: dict[str, Any] = {}
 
-            success_result = False
+            success = False
 
             if r.success:
                 data = r.out
                 try:
-                    parsed_data = json.loads(data)
+                    result = json.loads(data)
                 except Exception:
                     pass
 
-                if parsed_data and "error" not in parsed_data:
-                    success_result = True
+                if result and "error" not in result:
+                    success = True
 
             try:
-                bitrate_gbps = _calculate_gbps(self.test_type, parsed_data)
+                bitrate_gbps = _calculate_gbps(self.test_type, result)
             except Exception:
-                success_result = False
+                success = False
                 bitrate_gbps = Bitrate.NA
 
             return FlowTestOutput(
-                success=success_result,
+                success=success,
                 tft_metadata=self.ts.get_test_metadata(),
                 command=cmd,
-                result=parsed_data,
+                result=result,
                 bitrate_gbps=bitrate_gbps,
             )
 

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -191,13 +191,11 @@ class IperfClient(task.ClientTask):
             thread_action=_thread_action,
         )
 
-    def _aggregate_output(
+    def _aggregate_output_log_success(
         self,
         result: tftbase.AggregatableOutput,
     ) -> None:
         assert isinstance(result, FlowTestOutput)
-        if not result.success:
-            return
         if self.test_type == TestType.IPERF_TCP:
             ResultTcp(result.result).log()
         else:

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -194,7 +194,6 @@ class IperfClient(task.ClientTask):
     def _aggregate_output(
         self,
         result: tftbase.AggregatableOutput,
-        tft_result_builder: tftbase.TftResultBuilder,
     ) -> None:
         assert isinstance(result, FlowTestOutput)
         if not result.success:

--- a/tftbase.py
+++ b/tftbase.py
@@ -434,13 +434,9 @@ class TftResultBuilder:
             raise RuntimeError("Cannot set multiple FlowTestOutput results")
         self._flow_test = flow_test
 
-    def add_plugin(self, plugin_output: AggregatableOutput) -> PluginOutput:
-        if not isinstance(plugin_output, PluginOutput):
-            raise ValueError(
-                "Invalid parameter of type {type(plugin_output)} for add_plugin()"
-            )
+    def add_plugin(self, plugin_output: PluginOutput) -> None:
+        assert isinstance(plugin_output, PluginOutput)
         self._plugins.append(plugin_output)
-        return plugin_output
 
     def build(self) -> "TftResult":
         if self._flow_test is None:


### PR DESCRIPTION
- better validate the result when we receive it. This way, we ensure that the result dictionary contains what we expect, or we set `success=False` and a `msg` reason.
- move common code to the `Task.aggregate_output()` parent implementation.