### PR TITLE
[th/podman-rm-no-time] tft: avoid `--time` argument to `podman rm`

### DIFF
--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -50,7 +50,7 @@ class TrafficFlowTests:
             f"Cleaning external containers {task.EXTERNAL_PERF_SERVER} (if present)"
         )
         host.local.run(
-            f"podman rm --force --time 10 {task.EXTERNAL_PERF_SERVER}",
+            f"podman rm --force {task.EXTERNAL_PERF_SERVER}",
             log_level_fail=logging.WARN,
         )
 

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -52,6 +52,10 @@ class TrafficFlowTests:
         host.local.run(
             f"podman rm --force {task.EXTERNAL_PERF_SERVER}",
             log_level_fail=logging.WARN,
+            check_success=lambda r: (
+                r.success
+                or (r.returncode == 1 and "no container with name or ID" in r.err)
+            ),
         )
 
     def _create_log_paths_from_tests(self, test: testConfig.ConfTest) -> Path:


### PR DESCRIPTION
podman-rm got the "--time" argument in version 4.0 ([1]).

Note that ovn-kubernetes runs tests on Ubuntu 22.04, which installs podman 3.4.4+ds1-1ubuntu1.22.04.3. On such a system, we see
```
  2025-03-18T14:01:00.2536339Z 2025-03-18 14:01:00.253 INFO    [th:140076536012800]: Cleaning external containers external-perf-server (if present)
  2025-03-18T14:01:00.2783216Z 2025-03-18 14:01:00.278 WARNING [th:140076536012800]: cmd[5;localhost]: └──> 'podman rm --force --time 10 external-perf-server': failed (exit 125); err='Error: unknown flag: --time\n'
```
Avoid this option.

Also, the default appears to be already 10 seconds. Also, we expect that our pods run tini init and terminate quickly, without need to resorting to forceful killing.

[1] https://github.com/containers/podman/commit/21c9dc3c406bb486c44c4a27e5b0497bab1cd40d