### PR TITLE
[th/render-undefined-variables] task: rework setting template variables by moving to parent Task.get_template_args()

### DIFF
--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -61,12 +61,6 @@ class TaskMeasureCPU(PluginTask):
         )
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-        return {
-            **super().get_template_args(),
-            "pod_name": self.pod_name,
-        }
-
     def initialize(self) -> None:
         super().initialize()
         self.render_file("Server Pod Yaml")

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -65,7 +65,6 @@ class TaskMeasureCPU(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -73,7 +73,6 @@ class TaskMeasurePower(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -69,12 +69,6 @@ class TaskMeasurePower(PluginTask):
         )
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-        return {
-            **super().get_template_args(),
-            "pod_name": self.pod_name,
-        }
-
     def initialize(self) -> None:
         super().initialize()
         self.render_file("Server Pod Yaml")

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -170,7 +170,6 @@ class TaskValidateOffload(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -166,12 +166,6 @@ class TaskValidateOffload(PluginTask):
         self.perf_pod_name = perf_instance.pod_name
         self.perf_pod_type = perf_instance.pod_type
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-        return {
-            **super().get_template_args(),
-            "pod_name": self.pod_name,
-        }
-
     def initialize(self) -> None:
         super().initialize()
         self.render_file("Server Pod Yaml")

--- a/task.py
+++ b/task.py
@@ -332,7 +332,7 @@ class Task(ABC):
             "test_image": tftbase.get_tft_test_image(),
             "image_pull_policy": tftbase.get_tft_image_pull_policy(),
             "command": ["/usr/bin/container-entry-point.sh"],
-            "args": [],
+            "args": self._get_template_args_args(),
             "index": f"{self.index}",
             "node_name": self.node_name,
             "pod_name": self.pod_name,
@@ -355,6 +355,9 @@ class Task(ABC):
 
     def _get_template_args_port(self) -> str:
         return ""
+
+    def _get_template_args_args(self) -> list[str]:
+        return []
 
     def render_file(
         self,
@@ -790,6 +793,11 @@ class ServerTask(Task, ABC):
         if self.connection_mode == ConnectionMode.MULTI_NETWORK:
             self.create_ingress_multi_network_policy(self.port)
             self.create_egress_multi_network_policy(self.port)
+
+    def _get_template_args_args(self) -> list[str]:
+        if not self.exec_persistent:
+            return []
+        return self.cmd_line_args(for_template=True)
 
     def confirm_server_alive(self) -> None:
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:

--- a/task.py
+++ b/task.py
@@ -766,16 +766,11 @@ class ServerTask(Task, ABC):
         self.pod_name = pod_name
 
     def get_template_args(self) -> dict[str, str | list[str]]:
-
-        extra_args: dict[str, str] = {}
-        if self.connection_mode != ConnectionMode.EXTERNAL_IP:
-            extra_args["pod_name"] = self.pod_name
-            extra_args["port"] = f"{self.port}"
-
         return {
             **super().get_template_args(),
             "default_network": self.ts.node_server.default_network,
-            **extra_args,
+            "pod_name": self.pod_name,
+            "port": f"{self.port}",
         }
 
     def initialize(self) -> None:

--- a/task.py
+++ b/task.py
@@ -814,8 +814,11 @@ class ServerTask(Task, ABC):
         self.ts.event_server_alive.set()
 
     @abstractmethod
+    def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
+        raise RuntimeError()
+
     def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        pass
+        return shlex.join(self.cmd_line_args())
 
     @abstractmethod
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:

--- a/task.py
+++ b/task.py
@@ -335,6 +335,7 @@ class Task(ABC):
             "args": [],
             "index": f"{self.index}",
             "node_name": self.node_name,
+            "pod_name": self.pod_name,
             "secondary_network_nad": self.ts.connection.effective_secondary_network_nad,
             "use_secondary_network": (
                 "1" if self.ts.connection.secondary_network_nad else ""
@@ -771,7 +772,6 @@ class ServerTask(Task, ABC):
         return {
             **super().get_template_args(),
             "default_network": self.ts.node_server.default_network,
-            "pod_name": self.pod_name,
             "port": f"{self.port}",
         }
 
@@ -932,7 +932,6 @@ class ClientTask(Task, ABC):
         return {
             **super().get_template_args(),
             "default_network": self.ts.node_client.default_network,
-            "pod_name": self.pod_name,
             "port": "",
         }
 

--- a/task.py
+++ b/task.py
@@ -336,6 +336,7 @@ class Task(ABC):
             "index": f"{self.index}",
             "node_name": self.node_name,
             "pod_name": self.pod_name,
+            "port": self._get_template_args_port(),
             "secondary_network_nad": self.ts.connection.effective_secondary_network_nad,
             "use_secondary_network": (
                 "1" if self.ts.connection.secondary_network_nad else ""
@@ -351,6 +352,9 @@ class Task(ABC):
             ),
             "default_network": self.node.default_network,
         }
+
+    def _get_template_args_port(self) -> str:
+        return ""
 
     def render_file(
         self,
@@ -769,11 +773,8 @@ class ServerTask(Task, ABC):
         self.out_file_yaml = out_file_yaml
         self.pod_name = pod_name
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-        return {
-            **super().get_template_args(),
-            "port": f"{self.port}",
-        }
+    def _get_template_args_port(self) -> str:
+        return str(self.port)
 
     def initialize(self) -> None:
         super().initialize()
@@ -927,12 +928,6 @@ class ClientTask(Task, ABC):
         self.in_file_template = in_file_template
         self.out_file_yaml = out_file_yaml
         self.pod_name = pod_name
-
-    def get_template_args(self) -> dict[str, str | list[str]]:
-        return {
-            **super().get_template_args(),
-            "port": "",
-        }
 
     def initialize(self) -> None:
         super().initialize()

--- a/task.py
+++ b/task.py
@@ -21,8 +21,8 @@ from typing import TypeVar
 
 from ktoolbox import common
 from ktoolbox import host
-from ktoolbox import netdev
 from ktoolbox import kjinja2
+from ktoolbox import netdev
 from ktoolbox.k8sClient import K8sClient
 
 import testConfig
@@ -339,13 +339,15 @@ class Task(ABC):
             "use_secondary_network": (
                 "1" if self.ts.connection.secondary_network_nad else ""
             ),
-            "resource_name": self.ts.connection.resource_name
-            or Task._fetch_default_resource_name(
-                self.client,
-                self.get_namespace(),
-                self.ts.connection.secondary_network_nad,
-            )
-            or "",
+            "resource_name": (
+                self.ts.connection.resource_name
+                or Task._fetch_default_resource_name(
+                    self.client,
+                    self.get_namespace(),
+                    self.ts.connection.secondary_network_nad,
+                )
+                or ""
+            ),
         }
 
     def render_file(

--- a/task.py
+++ b/task.py
@@ -349,6 +349,7 @@ class Task(ABC):
                 )
                 or ""
             ),
+            "default_network": self.node.default_network,
         }
 
     def render_file(
@@ -771,7 +772,6 @@ class ServerTask(Task, ABC):
     def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
-            "default_network": self.ts.node_server.default_network,
             "port": f"{self.port}",
         }
 
@@ -931,7 +931,6 @@ class ClientTask(Task, ABC):
     def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
-            "default_network": self.ts.node_client.default_network,
             "port": "",
         }
 

--- a/task.py
+++ b/task.py
@@ -936,6 +936,7 @@ class ClientTask(Task, ABC):
             **super().get_template_args(),
             "default_network": self.ts.node_client.default_network,
             "pod_name": self.pod_name,
+            "port": "",
         }
 
     def initialize(self) -> None:

--- a/task.py
+++ b/task.py
@@ -382,7 +382,14 @@ class Task(ABC):
             out_file=out_file_yaml,
         )
 
-        rendered_dict = yaml.safe_load(rendered)
+        try:
+            rendered_dict = yaml.safe_load(rendered)
+        except Exception as e:
+            logger.error(
+                f'"{in_file_template}" rendered as {repr(rendered)} is not valid YAML: {e}'
+            )
+            raise
+
         logger.debug(f'"{in_file_template}" contains: {json.dumps(rendered_dict)}')
 
     def initialize(self) -> None:

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -34,7 +34,7 @@ TestTypeHandler.register_test_type(TestTypeHandlerHttp())
 
 
 class HttpServer(task.ServerTask):
-    def cmd_line_args(self) -> list[str]:
+    def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
         return [
             "python3",
             "-m",
@@ -48,7 +48,7 @@ class HttpServer(task.ServerTask):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args()
+            extra_args["args"] = self.cmd_line_args(for_template=True)
 
         return {
             **super().get_template_args(),

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -1,4 +1,3 @@
-import shlex
 import time
 
 from dataclasses import dataclass
@@ -54,9 +53,6 @@ class HttpServer(task.ServerTask):
             **super().get_template_args(),
             **extra_args,
         }
-
-    def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return "killall python3"

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -43,17 +43,6 @@ class HttpServer(task.ServerTask):
             f"{self.port}",
         ]
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-
-        extra_args: dict[str, str | list[str]] = {}
-        if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args(for_template=True)
-
-        return {
-            **super().get_template_args(),
-            **extra_args,
-        }
-
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return "killall python3"
 

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -121,17 +121,6 @@ class IperfServer(task.ServerTask):
             *extra_args,
         ]
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-
-        extra_args: dict[str, str | list[str]] = {}
-        if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args(for_template=True)
-
-        return {
-            **super().get_template_args(),
-            **extra_args,
-        }
-
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {IPERF_EXE}"
 

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -108,11 +108,19 @@ TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_UDP))
 
 
 class IperfServer(task.ServerTask):
+    def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
+        return [
+            IPERF_EXE,
+            "-s",
+            "-p",
+            f"{self.port}",
+        ]
+
     def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["args"] = [IPERF_EXE, "-s", "-p", f"{self.port}"]
+            extra_args["args"] = self.cmd_line_args(for_template=True)
 
         return {
             **super().get_template_args(),

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import shlex
 import task
 
 from collections.abc import Mapping
@@ -132,9 +131,6 @@ class IperfServer(task.ServerTask):
             **super().get_template_args(),
             **extra_args,
         }
-
-    def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {IPERF_EXE}"

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -1,5 +1,6 @@
-import logging
 import json
+import logging
+import shlex
 import task
 
 from collections.abc import Mapping
@@ -109,11 +110,16 @@ TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_UDP))
 
 class IperfServer(task.ServerTask):
     def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
+        if for_template:
+            extra_args = []
+        else:
+            extra_args = ["--one-off", "--json"]
         return [
             IPERF_EXE,
             "-s",
             "-p",
             f"{self.port}",
+            *extra_args,
         ]
 
     def get_template_args(self) -> dict[str, str | list[str]]:
@@ -128,7 +134,7 @@ class IperfServer(task.ServerTask):
         }
 
     def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return f"{IPERF_EXE} -s -p {self.port} --one-off --json"
+        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {IPERF_EXE}"

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -1,5 +1,3 @@
-import shlex
-
 from dataclasses import dataclass
 from typing import Any
 from typing import Optional
@@ -96,9 +94,6 @@ class NetPerfServer(task.ServerTask):
             **super().get_template_args(),
             **extra_args,
         }
-
-    def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {NETPERF_SERVER_EXE}"

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -76,11 +76,19 @@ TestTypeHandler.register_test_type(TestTypeHandlerNetPerf(TestType.NETPERF_TCP_R
 
 
 class NetPerfServer(task.ServerTask):
+    def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
+        return [
+            NETPERF_SERVER_EXE,
+            "-p",
+            f"{self.port}",
+            "-N",
+        ]
+
     def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["args"] = [NETPERF_SERVER_EXE, "-p", f"{self.port}", "-N"]
+            extra_args["args"] = self.cmd_line_args(for_template=True)
 
         return {
             **super().get_template_args(),

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -1,3 +1,5 @@
+import shlex
+
 from dataclasses import dataclass
 from typing import Any
 from typing import Optional
@@ -96,7 +98,7 @@ class NetPerfServer(task.ServerTask):
         }
 
     def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return f"{NETPERF_SERVER_EXE} -p {self.port} -N"
+        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {NETPERF_SERVER_EXE}"

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -84,17 +84,6 @@ class NetPerfServer(task.ServerTask):
             "-N",
         ]
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-
-        extra_args: dict[str, str | list[str]] = {}
-        if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args(for_template=True)
-
-        return {
-            **super().get_template_args(),
-            **extra_args,
-        }
-
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return f"killall {NETPERF_SERVER_EXE}"
 

--- a/testTypeSimple.py
+++ b/testTypeSimple.py
@@ -34,7 +34,7 @@ CMD_SIMPLE_TCP_SERVER_CLIENT = "simple-tcp-server-client"
 
 
 class SimpleServer(task.ServerTask):
-    def cmd_line_args(self) -> list[str]:
+    def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
         return [
             CMD_SIMPLE_TCP_SERVER_CLIENT,
             "--server",
@@ -49,7 +49,7 @@ class SimpleServer(task.ServerTask):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args()
+            extra_args["args"] = self.cmd_line_args(for_template=True)
 
         return {
             **super().get_template_args(),

--- a/testTypeSimple.py
+++ b/testTypeSimple.py
@@ -45,17 +45,6 @@ class SimpleServer(task.ServerTask):
             *(self.ts.cfg_descr.get_server().args or ()),
         ]
 
-    def get_template_args(self) -> dict[str, str | list[str]]:
-
-        extra_args: dict[str, str | list[str]] = {}
-        if self.exec_persistent:
-            extra_args["args"] = self.cmd_line_args(for_template=True)
-
-        return {
-            **super().get_template_args(),
-            **extra_args,
-        }
-
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return "killall python3"
 

--- a/testTypeSimple.py
+++ b/testTypeSimple.py
@@ -56,9 +56,6 @@ class SimpleServer(task.ServerTask):
             **extra_args,
         }
 
-    def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return shlex.join(self.cmd_line_args())
-
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return "killall python3"
 


### PR DESCRIPTION
With a recent change in ktoolbox.kjinja2.render_data(), the function now errors out (by default) if an undefined variable is referenced. That is useful, to find bugs about undefined variables in Jinja2 templates.

There are known cases where we render manifest files for client pods, that refer to `{{port}}` jinja2 variable, but `Task.get_template_args()` does not set that variable. That leads to a crash. Fix that.

But also, let the parent implementation in `Task.get_template_args()` set more of those variables. Instead of subclasses overwriting `get_template_args()`, the Task parent class is already aware of most of those parameters (`pod_name`, `port`, `test_image`, `default_network`). Let the parent class always set those variables, so that subclasses don't need to. This means we less carefully try to set variables only for manifest templates that need them, but rather define common variables always (in the base class). The benefit is that we need to less carefully estimate when a variable is needed, and just always set it at one place.

Also, simplify constructing the `cmd_line_args()` for `ServerTask` subclasses.