### PR TITLE
[th/simple-exec] add "--exec" option to "simple" test to run arbitrary script instead

### DIFF
--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TAG="${TAG:-quay.io/$USER/kubernetes-traffic-flow-tests:latest}"
+
+set -ex
+
+TAG="${1:-$TAG}"
+
+buildah manifest rm kubernetes-traffic-flow-tests-manifest || true
+buildah manifest create kubernetes-traffic-flow-tests-manifest
+buildah build --manifest kubernetes-traffic-flow-tests-manifest --platform linux/amd64,linux/arm64 -t "$TAG" .
+buildah manifest push --all kubernetes-traffic-flow-tests-manifest "docker://$TAG"


### PR DESCRIPTION
One point of the "simple" test is to allow to hack the test and do
whatever we want (for example, modify the python script).
    
However, the simple script that we run is still inside the container.
So to modify the script, you would have to rebuild the container and
select it via TFT_TEST_IMAGE environment variable. That is still
cumbersome.
    
Now, add an "--exec" option. If set, the python script will download
that URL, make it executable and execute it. This way, you can more
easily inject another script to run during the test.
    
You can specify both "--exec" and "--exec-args" option in tft via "tft[0].connections[0].{server,client}.args" parameter. For example:
    
    tft:
      - name: ...
        ...
        connections:
          - name: ...
            type: "simple"
            server:
              - name: ...
            client:
              - name: ...
                args: "--exec https://my/script.sh --exec-args hello"
