### PR TITLE
[th/tft-check] add "--check" option to `tft.py` to check the test results

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -136,11 +136,11 @@ def parse_args() -> argparse.Namespace:
 
     if args.config and not Path(args.config).exists():
         logger.error(f"No config file found at {args.config}, exiting")
-        sys.exit(-1)
+        sys.exit(common.EX_CONFIG)
 
     if not args.logs or not Path(args.logs).exists():
         logger.error(f"Log file {args.logs} does not exist")
-        sys.exit(-1)
+        sys.exit(common.EX_CONFIG)
 
     return args
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -88,7 +88,10 @@ class Evaluator:
         tft_results: TftResults,
     ) -> TftResults:
         lst = [self.eval_test_result(tft_result) for tft_result in tft_results]
-        return TftResults(lst=tuple(lst))
+        return TftResults(
+            lst=tuple(lst),
+            filename=tft_results.filename,
+        )
 
     def eval_from_file(
         self,

--- a/evaluator.py
+++ b/evaluator.py
@@ -154,4 +154,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common.run_main(main)

--- a/generate_eval_config.py
+++ b/generate_eval_config.py
@@ -358,4 +358,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common.run_main(main)

--- a/print_results.py
+++ b/print_results.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
-import traceback
 
 from typing import Optional
 
@@ -87,7 +85,7 @@ def process_file(result_file: str) -> bool:
     return not group_fail
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
 
     failed_files: list[str] = []
@@ -99,15 +97,11 @@ def main() -> None:
     print()
     if failed_files:
         print(f"Failures detected in {repr(failed_files)}")
-        sys.exit(1)
+        return 1
 
     print("No failures detected in results")
-    sys.exit(0)
+    return 0
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception:
-        traceback.print_exc()
-        sys.exit(2)
+    common.run_main(main)

--- a/print_results.py
+++ b/print_results.py
@@ -2,11 +2,15 @@
 
 import argparse
 
+from collections.abc import Iterable
 from typing import Optional
 
 from ktoolbox import common
 
 import tftbase
+
+
+EXIT_CODE_VALIDATION = 1
 
 
 def print_flow_test_output(test_output: Optional[tftbase.FlowTestOutput]) -> None:
@@ -47,6 +51,40 @@ def print_tft_results(tft_results: tftbase.TftResults) -> None:
         print_tft_result(tft_result)
 
 
+def process_results(tft_results: tftbase.TftResults) -> bool:
+
+    group_success, group_fail = tft_results.group_by_success()
+
+    print(
+        f"There are {len(group_success)} passing flows{tft_results.log_detail}.{' Details:' if group_success else ''}"
+    )
+    print_tft_results(group_success)
+
+    print(
+        f"There are {len(group_fail)} failing flows{tft_results.log_detail}.{' Details:' if group_fail else ''}"
+    )
+    print_tft_results(group_fail)
+
+    print()
+    return not group_fail
+
+
+def process_results_all(tft_results_lst: Iterable[tftbase.TftResults]) -> bool:
+    failed_files: list[str] = []
+
+    for tft_results in common.iter_eval_now(tft_results_lst):
+        if not process_results(tft_results):
+            failed_files.append(common.unwrap(tft_results.filename))
+
+    print()
+    if failed_files:
+        print(f"Failures detected in {repr(failed_files)}")
+        return False
+
+    print("No failures detected in results")
+    return True
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Tool to prettify the TFT Flow test results"
@@ -65,42 +103,12 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def process_file(result_file: str) -> bool:
-
-    tft_results = tftbase.TftResults.parse_from_file(result_file)
-
-    group_success, group_fail = tft_results.group_by_success()
-
-    print(
-        f"There are {len(group_success)} passing flows in {repr(result_file)}.{' Details:' if group_success else ''}"
-    )
-    print_tft_results(group_success)
-
-    print(
-        f"There are {len(group_fail)} failing flows in {repr(result_file)}.{' Details:' if group_fail else ''}"
-    )
-    print_tft_results(group_fail)
-
-    print()
-    return not group_fail
-
-
 def main() -> int:
     args = parse_args()
-
-    failed_files: list[str] = []
-
-    for result_file in args.result:
-        if not process_file(result_file):
-            failed_files.append(result_file)
-
-    print()
-    if failed_files:
-        print(f"Failures detected in {repr(failed_files)}")
-        return 1
-
-    print("No failures detected in results")
-    return 0
+    success = process_results_all(
+        tftbase.TftResults.parse_from_file(file) for file in args.result
+    )
+    return 0 if success else EXIT_CODE_VALIDATION
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ PyYAML
 jc
 jinja2
 paramiko
-git+https://github.com/thom311/ktoolbox@bf48df525a340c5a349741282e636c497a7abcbd
+git+https://github.com/thom311/ktoolbox@ea3b0db7b1b3639d1927d0e7ed9495dca746a5d6

--- a/task.py
+++ b/task.py
@@ -146,7 +146,7 @@ class TaskOperation:
 
             logger.error(f"thread[{self.log_name}]: action raised exception {e}")
             logger.error(f"backtrace:\n{traceback.format_exc()}")
-            os._exit(-1)
+            os._exit(common.EX_SOFTWARE)
 
         with self._lock:
             assert not hasattr(self, "_intermediate_result")

--- a/task.py
+++ b/task.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import shlex
-import sys
 import threading
 import time
 import typing
@@ -822,9 +821,9 @@ class ServerTask(Task, ABC):
             r = self.run_oc(
                 f"wait --for=condition=ready pod/{self.pod_name} --timeout=1m"
             )
-        if not r or not r.success:
-            logger.error(f"Failed to start server: {r.err}")
-            sys.exit(-1)
+        if not r:
+            logger.error(f"Failed to start server {self.pod_name}: {r.err}")
+            raise RuntimeError(f"Failed to start server {self.pod_name}: {r.err}")
 
         self.ts.event_server_alive.set()
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -222,7 +222,7 @@ def test_output_list_parse(
         assert isinstance(output, tftbase.TftResults)
 
     data2 = output.serialize()
-    output2 = tftbase.TftResults.parse(data2)
+    output2 = tftbase.TftResults.parse(data2, filename=filename)
     assert isinstance(output2, tftbase.TftResults)
     assert output == output2
 

--- a/tft.py
+++ b/tft.py
@@ -80,4 +80,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common.run_main(main)

--- a/tft.py
+++ b/tft.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from ktoolbox import common
 
+import print_results
+
 from evaluator import Evaluator
 from testConfig import ConfigDescriptor
 from testConfig import TestConfig
@@ -48,6 +50,13 @@ def parse_args() -> argparse.Namespace:
         'the current directory. If unspecified, the files are written to "${logs}/${timestamp}.json" '
         'where "${logs}" can be specified in the config file (and defaults to "./ft-logs/").',
     )
+    parser.add_argument(
+        "-c",
+        "--check",
+        type=bool,
+        default=False,
+        help='By default, the program only runs the tests and writes the results. It is not expected to fail unless a serious error happened. In that case, you usually want to run `print_results.py` command afterwards. Passing "--check" combines those two steps in one and the `tft.py` command succeeds only if all tests pass.',
+    )
 
     common.log_argparse_add_argument_verbosity(parser)
 
@@ -61,7 +70,7 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
 
     tc = TestConfig(
@@ -75,8 +84,17 @@ def main() -> None:
 
     evaluator = Evaluator(tc.evaluator_config)
 
+    tft_results_lst = []
+
     for cfg_descr in ConfigDescriptor(tc).describe_all_tft():
-        tft.test_run(cfg_descr, evaluator)
+        tft_results = tft.test_run(cfg_descr, evaluator)
+        tft_results_lst.append(tft_results)
+
+    if args.check:
+        if not print_results.process_results_all(tft_results_lst):
+            return print_results.EXIT_CODE_VALIDATION
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/tftbase.py
+++ b/tftbase.py
@@ -480,6 +480,7 @@ class TftResult:
 @dataclass(frozen=True, kw_only=True)
 class TftResults:
     lst: tuple[TftResult, ...]
+    filename: Optional[str] = None
 
     TFT_TESTS: typing.ClassVar[str] = "tft-tests"
 
@@ -488,6 +489,12 @@ class TftResults:
 
     def __len__(self) -> int:
         return len(self.lst)
+
+    @property
+    def log_detail(self) -> str:
+        if self.filename is None:
+            return ""
+        return f" in {repr(self.filename)}"
 
     def serialize(self) -> dict[str, Any]:
         return {
@@ -547,7 +554,10 @@ class TftResults:
                         f'{err} has invalid plugin name "{plugin_output.plugin_metadata.plugin_name}" in result #{r_idx}'
                     )
 
-        return TftResults(lst=tuple(lst))
+        return TftResults(
+            lst=tuple(lst),
+            filename=(str(filename) if filename is not None else None),
+        )
 
     @staticmethod
     def parse_from_file(filename: str | Path) -> "TftResults":
@@ -580,8 +590,8 @@ class TftResults:
         group_fail.sort(key=_key_fcn)
 
         return (
-            TftResults(lst=tuple(group_success)),
-            TftResults(lst=tuple(group_fail)),
+            TftResults(lst=tuple(group_success), filename=self.filename),
+            TftResults(lst=tuple(group_fail), filename=self.filename),
         )
 
     def get_pass_fail_status(self) -> "PassFailStatus":

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -156,7 +156,7 @@ class TrafficFlowTests:
         self,
         cfg_descr: ConfigDescriptor,
         evaluator: Evaluator,
-    ) -> None:
+    ) -> TftResults:
         test = cfg_descr.get_tft()
         self._configure_namespace(cfg_descr)
         self._cleanup_previous_testspace(cfg_descr)
@@ -182,3 +182,8 @@ class TrafficFlowTests:
 
         if not result_status.result:
             logger.error(f"Failure detected in {cfg_descr.get_tft().name} results")
+
+        return TftResults(
+            lst=tft_results.lst,
+            filename=str(log_file),
+        )


### PR DESCRIPTION
- rework the handling of `sys.exit()`
- refactor code in `print_results.py` to make it usable from `tft.py`.
- add a `--check` option to `tft.py`. When set, the behavior is as if the `tft.py` call was automatically followed by a `print_results.py` run. Note that with this, we log the pretty-printed results at the end of `tft.py` and exit with code 1, if any tests failed. Otherwise, `tft.py` command usually succeeds, regardless whether any tests failed.