### PR TITLE
[th/kubeconfig-option] tft: add "--kubeconfig{,-infra}" options to overwrite configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,5 @@ Simply run the python application as so:
      your own variants of the files from "manifests" directory and they will be preferred.
 - `TFT_MANIFESTS_YAMLS` to specify the output directory for rendered manifests. This
      defaults to "manifests/yamls".
+- `TFT_KUBECONFIG`, `TFT_KUBECONFIG_INFRA` to overwrite the kubeconfigs from the configuration
+     file. See also the "--kubeconfig" and "--kubeconfig-infra" command line options.


### PR DESCRIPTION
Make this more configurable. The kubeconfig for tenant/infra can now be configured via:

 - command line "--kubeconfig"/"--kubeconfig-infra"
 - environment variables "$TFT_KUBECONFIG"/"$TFT_KUBECONFIG_INFRA"
 - config file "kubeconfig"/"kubeconfig_infra"
 - autodetect based on files in "/root/kubeconfig*"

Note that if you configure the kubeconfig/kubeconfig-infra at one kind (e.g. environment variable), then the other one must also come from the same source. For example, if you set "--kubeconfig-infra" on the command line, then the kubeconfig must also be specified on the command line. That is partly because the kubeconfig-infra is optional and may be unset. So when you set "--kubeconfig" without "--kubeconfig-infra", that is an indication that the kubeconfig-infra is unset.

The use is to make it easier to overwrite settings from the configuration file. For example, dpu-operator's `make e2e-test` specifies the kubeconfig files in the configuration files, as it fits what the tools sets up using cluster-deployment-automation. So, if you don't use CDA to setup your cluster, it would still be useful to run `make traffic-flow-tests`. If only you could specify different kubeconfigs. These new options will allow for that.