### PR TITLE
[th/privileged-pod] task: support configuring test pods as priviledged

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ tft:
           - name: "(8)"
             persistent: "(9)"
             sriov: "(10)"
-            default-network: "(11)"
+            default_network: "(11)"
         client:
           - name: "(12)"
             sriov: "(13)"
-            default-network: "(14)"
+            default_network: "(14)"
         plugins:
           - name: (15)
           - name: (15)
@@ -106,10 +106,10 @@ kubeconfig_infra: (18)
 8. "name" - The node name of the server.
 9. "persistent" - Whether to have the server pod persist after the test. Takes in "true/false"
 10. "sriov" - Whether SRIOV should be used for the server pod. Takes in "true/false"
-11. "default-network" - (Optional) The name of the default network that the sriov pod would use.
+11. "default_network" - (Optional) The name of the default network that the sriov pod would use.
 12. "name" - The node name of the client.
 13. "sriov" - Whether SRIOV should be used for the client pod. Takes in "true/false"
-14. "default-network" - (Optional) The name of the default network that the sriov pod would use.
+14. "default_network" - (Optional) The name of the default network that the sriov pod would use.
 15. "name" - (Optional) list of plugin names
     | Name             | Description          |
     | ---------------- | -------------------- |

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Simply run the python application as so:
 - `TFT_IMAGE_PULL_POLICY` the image pull policy. One of `IfNotPresent`, `Always`, `Never`.
      Defaults to `IfNotPresent`m unless `$TFT_TEST_IMAGE` is set (in which case it defaults
      to `Always`).
+- `TFT_PRIVILEGED_POD` sets whether test pods are privileged. This overwrites the settings
+     from the configuration YAML.
 - `TFT_MANIFESTS_OVERRIDES` to specify an overrides directory for manifests. If not set, the
      default is "manifests/overrides". If set to empty, no overrides are used. You can place
      your own variants of the files from "manifests" directory and they will be preferred.

--- a/manifests/host-pod.yaml.j2
+++ b/manifests/host-pod.yaml.j2
@@ -18,5 +18,6 @@ spec:
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
     securityContext:
+      privileged: {{ privileged_pod }}
       capabilities:
         add: ["NET_ADMIN","NET_RAW"]

--- a/manifests/pod-secondary-network.yaml.j2
+++ b/manifests/pod-secondary-network.yaml.j2
@@ -17,3 +17,5 @@ spec:
     command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
+    securityContext:
+      privileged: {{ privileged_pod }}

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -15,3 +15,5 @@ spec:
     command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
+    securityContext:
+      privileged: {{ privileged_pod }}

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -23,3 +23,5 @@ spec:
         {{ resource_name }}: '1'
       limits:
         {{ resource_name }}: '1' {% endif %}
+    securityContext:
+      privileged: {{ privileged_pod }}

--- a/task.py
+++ b/task.py
@@ -336,6 +336,10 @@ class Task(ABC):
             "node_name": self.node_name,
             "pod_name": self.pod_name,
             "port": self._get_template_args_port(),
+            "privileged_pod": common.bool_to_str(
+                self._get_template_args_privileged_pod(),
+                format="true",
+            ),
             "secondary_network_nad": self.ts.connection.effective_secondary_network_nad,
             "use_secondary_network": (
                 "1" if self.ts.connection.secondary_network_nad else ""
@@ -351,6 +355,18 @@ class Task(ABC):
             ),
             "default_network": self.node.default_network,
         }
+
+    def _get_template_args_privileged_pod(self) -> bool:
+        v = self.node.privileged_pod
+        if v is not None:
+            # The per-node setting has precedence.
+            return v
+        v = tftbase.get_tft_privileged_pod()
+        if v is not None:
+            # Then the setting from the environment variable.
+            return v
+        # Finaly, the test-wide setting fro the configruration file.
+        return self.ts.cfg_descr.get_tft().privileged_pod
 
     def _get_template_args_port(self) -> str:
         return ""

--- a/testConfig.py
+++ b/testConfig.py
@@ -87,7 +87,7 @@ class ConfNodeBase(_ConfBaseConnectionItem, abc.ABC):
         return {
             **super().serialize(),
             "sriov": self.sriov,
-            "default-network": self.default_network,
+            "default_network": self.default_network,
             **d,
         }
 
@@ -106,9 +106,14 @@ class ConfNodeBase(_ConfBaseConnectionItem, abc.ABC):
             )
 
             default_network = common.structparse_pop_str(
-                varg.for_key("default-network"),
-                default="default/default",
+                varg.for_key("default_network"),
+                default=None,
             )
+            if default_network is None:
+                default_network = common.structparse_pop_str(
+                    varg.for_key("default-network"),
+                    default="default/default",
+                )
 
             privileged_pod = common.structparse_pop_bool(
                 varg.for_key("privileged_pod"),

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -165,6 +165,7 @@ tft:
          - name: c1
            args: "foo '-x x'"
            privileged_pod: False
+           default-network: default--n
        server:
          - name: s1
            args:
@@ -204,6 +205,7 @@ kubeconfig_infra: /path/to/kubeconfig_infra
     assert tc.config.tft[0].connections[1].test_type == TestType.SIMPLE
     assert tc.config.tft[0].connections[1].client[0].privileged_pod is False
     assert tc.config.tft[0].connections[1].client[0].args == ("foo", "-x x")
+    assert tc.config.tft[0].connections[1].client[0].default_network == "default--n"
     assert tc.config.tft[0].connections[1].server[0].args == ("hi x",)
     assert tc.config.tft[0].connections[1].server[0].privileged_pod is None
     assert tc.config.tft[0].get_output_file() == pathlib.Path("/tmp/result-000.json")

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -153,6 +153,7 @@ tft:
       - 2
       - HOST_TO_POD_DIFF_NODE
       - HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE - HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    privileged_pod: True
     connections:
      - name: con1
        plugins:
@@ -163,6 +164,7 @@ tft:
        client:
          - name: c1
            args: "foo '-x x'"
+           privileged_pod: False
        server:
          - name: s1
            args:
@@ -200,9 +202,12 @@ kubeconfig_infra: /path/to/kubeconfig_infra
     assert tc.config.tft[0].connections[0].plugins[1].name == "measure_power"
 
     assert tc.config.tft[0].connections[1].test_type == TestType.SIMPLE
+    assert tc.config.tft[0].connections[1].client[0].privileged_pod is False
     assert tc.config.tft[0].connections[1].client[0].args == ("foo", "-x x")
     assert tc.config.tft[0].connections[1].server[0].args == ("hi x",)
+    assert tc.config.tft[0].connections[1].server[0].privileged_pod is None
     assert tc.config.tft[0].get_output_file() == pathlib.Path("/tmp/result-000.json")
+    assert tc.config.tft[0].privileged_pod is True
 
     _check_testConfig(tc)
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -23,6 +23,8 @@ logger = common.ExtendedLogger("tft." + __name__)
 ENV_TFT_TEST_IMAGE = "TFT_TEST_IMAGE"
 ENV_TFT_IMAGE_PULL_POLICY = "TFT_IMAGE_PULL_POLICY"
 
+ENV_TFT_PRIVILEGED_POD = "TFT_PRIVILEGED_POD"
+
 ENV_TFT_TEST_IMAGE_DEFAULT = (
     "ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest"
 )
@@ -67,6 +69,16 @@ def get_tft_image_pull_policy() -> str:
             s = "IfNotPresent"
     logger.info(f"env: {ENV_TFT_IMAGE_PULL_POLICY}={shlex.quote(s)}")
     return s
+
+
+@functools.cache
+def get_tft_privileged_pod() -> Optional[bool]:
+    d = get_environ(ENV_TFT_PRIVILEGED_POD)
+    value = common.str_to_bool(d, on_default=None)
+    logger.info(
+        f"env: {ENV_TFT_PRIVILEGED_POD}={common.bool_to_str(value) if value is not None else ''}"
+    )
+    return value
 
 
 @functools.cache


### PR DESCRIPTION
Usually we don't need this, and usually we want to run with restricted permissions to be closer to what the user would do.

However, for testing it can be useful (e.g. to exec tcpdump in a running container). Make it configurable via configuration YAML and `TFT_PRIVILEGED_POD` environment variable.