### PR TITLE
[th/node-name-cleanup] cleanups around node name

### DIFF
--- a/manifests/host-pod.yaml.j2
+++ b/manifests/host-pod.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: {{ name_space }}
-  name: {{ pod_name }}
+  name: "{{ pod_name }}"
   labels:
     tft-tests: "{{ index }}"
     tft-port: "{{ port }}"
@@ -10,9 +10,9 @@ spec:
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet
   nodeSelector:
-    kubernetes.io/hostname: {{ node_name }}
+    kubernetes.io/hostname: "{{ node_name }}"
   containers:
-  - name: {{ pod_name }}
+  - name: "{{ pod_name }}"
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}

--- a/manifests/pod-secondary-network.yaml.j2
+++ b/manifests/pod-secondary-network.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: {{ name_space }}
-  name: {{ pod_name }}
+  name: "{{ pod_name }}"
   labels:
     tft-tests: "{{ index }}"
     tft-port: "{{ port }}"
@@ -10,9 +10,9 @@ metadata:
     k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }}
 spec:
   nodeSelector:
-    kubernetes.io/hostname: {{ node_name }}
+    kubernetes.io/hostname: "{{ node_name }}"
   containers:
-  - name: {{ pod_name }}
+  - name: "{{ pod_name }}"
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: {{ name_space }}
-  name: {{ pod_name }}
+  name: "{{ pod_name }}"
   labels:
     tft-tests: "{{ index }}"
     tft-port: "{{ port }}"
 spec:
   nodeSelector:
-    kubernetes.io/hostname: {{ node_name }}
+    kubernetes.io/hostname: "{{ node_name }}"
   containers:
-  - name: {{ pod_name }}
+  - name: "{{ pod_name }}"
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: {{ name_space }}
-  name: {{ pod_name }}
+  name: "{{ pod_name }}"
   annotations: {% if not use_secondary_network %}
     v1.multus-cni.io/default-network: {{ default_network }} {% else %}
     k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }} {% endif %}
@@ -11,9 +11,9 @@ metadata:
     tft-port: "{{ port }}"
 spec:
   nodeSelector:
-    kubernetes.io/hostname: {{ node_name }}
+    kubernetes.io/hostname: "{{ node_name }}"
   containers:
-  - name: {{ pod_name }}
+  - name: "{{ pod_name }}"
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}

--- a/manifests/tools-pod.yaml.j2
+++ b/manifests/tools-pod.yaml.j2
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: {{ name_space }}
-  name: {{ pod_name }}
+  name: "{{ pod_name }}"
   labels:
     tft-tests: "{{ index }}"
 spec:
   nodeSelector:
-    kubernetes.io/hostname: {{ node_name }}
+    kubernetes.io/hostname: "{{ node_name }}"
   hostNetwork: true
   containers:
-  - name: {{ pod_name }}
+  - name: "{{ pod_name }}"
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -60,7 +60,7 @@ class TaskMeasureCPU(PluginTask):
 
     def initialize(self) -> None:
         super().initialize()
-        self.render_file("Server Pod Yaml")
+        self.render_pod_file("Plugin Pod Yaml")
 
     def _create_task_operation(self) -> TaskOperation:
         def _thread_action() -> BaseOutput:

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -56,7 +56,6 @@ class TaskMeasureCPU(PluginTask):
 
         self.pod_name = f"tools-pod-{self.node_name_sanitized()}-measure-cpu"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = tftbase.get_manifest_renderpath(self.pod_name + ".yaml")
 
     def initialize(self) -> None:
         super().initialize()

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -54,7 +54,7 @@ class TaskMeasureCPU(PluginTask):
             tenant=tenant,
         )
 
-        self.pod_name = f"tools-pod-{self.node_name_sanitized()}-measure-cpu"
+        self.pod_name = f"tools-pod-{self.node_name_sanitized}-measure-cpu"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
 
     def initialize(self) -> None:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -62,7 +62,7 @@ class TaskMeasurePower(PluginTask):
             tenant=tenant,
         )
 
-        self.pod_name = f"tools-pod-{self.node_name_sanitized()}-measure-cpu"
+        self.pod_name = f"tools-pod-{self.node_name_sanitized}-measure-cpu"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
 
     def initialize(self) -> None:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -68,7 +68,7 @@ class TaskMeasurePower(PluginTask):
 
     def initialize(self) -> None:
         super().initialize()
-        self.render_file("Server Pod Yaml")
+        self.render_pod_file("Plugin Pod Yaml")
 
     def _create_task_operation(self) -> TaskOperation:
         def _thread_action() -> BaseOutput:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -64,7 +64,6 @@ class TaskMeasurePower(PluginTask):
 
         self.pod_name = f"tools-pod-{self.node_name_sanitized()}-measure-cpu"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = tftbase.get_manifest_renderpath(self.pod_name + ".yaml")
 
     def initialize(self) -> None:
         super().initialize()

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -165,7 +165,7 @@ class TaskValidateOffload(PluginTask):
 
     def initialize(self) -> None:
         super().initialize()
-        self.render_file("Server Pod Yaml")
+        self.render_pod_file("Plugin Pod Yaml")
 
     def _create_task_operation(self) -> TaskOperation:
         def _thread_action() -> BaseOutput:

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -156,7 +156,7 @@ class TaskValidateOffload(PluginTask):
             tenant=tenant,
         )
 
-        self.pod_name = f"tools-pod-{self.node_name_sanitized()}-validate-offload"
+        self.pod_name = f"tools-pod-{self.node_name_sanitized}-validate-offload"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
         self._perf_instance = perf_instance
         self.perf_pod_name = perf_instance.pod_name

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -158,7 +158,6 @@ class TaskValidateOffload(PluginTask):
 
         self.pod_name = f"tools-pod-{self.node_name_sanitized()}-validate-offload"
         self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
-        self.out_file_yaml = tftbase.get_manifest_renderpath(self.pod_name + ".yaml")
         self._perf_instance = perf_instance
         self.perf_pod_name = perf_instance.pod_name
         self.perf_pod_type = perf_instance.pod_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ PyYAML
 jc
 jinja2
 paramiko
-git+https://github.com/thom311/ktoolbox@d30bacd0e4e71c470f276cc9192d7ae117a45a02
+git+https://github.com/thom311/ktoolbox@7708daaf4f8c1fc49b560a17c4f5f66690b34c35

--- a/task.py
+++ b/task.py
@@ -291,7 +291,7 @@ class Task(ABC):
         return self.node.name
 
     def node_name_sanitized(self) -> str:
-        return self.node_name.replace(".", "-")
+        return tftbase.str_sanitize(self.node_name)
 
     def get_namespace(self) -> str:
         return self.ts.cfg_descr.get_tft().namespace

--- a/task.py
+++ b/task.py
@@ -290,6 +290,7 @@ class Task(ABC):
     def node_name(self) -> str:
         return self.node.name
 
+    @property
     def node_name_sanitized(self) -> str:
         return tftbase.str_sanitize(self.node_name)
 
@@ -764,7 +765,7 @@ class ServerTask(Task, ABC):
 
         connection_mode = ts.connection_mode
         pod_type = ts.server_pod_type
-        node_name_sanitized = self.node_name_sanitized()
+        node_name_sanitized = self.node_name_sanitized
         port = 5201 + self.index
 
         if connection_mode == ConnectionMode.EXTERNAL_IP:
@@ -920,7 +921,7 @@ class ClientTask(Task, ABC):
         )
 
         pod_type = ts.client_pod_type
-        node_name_sanitized = self.node_name_sanitized()
+        node_name_sanitized = self.node_name_sanitized
         port = server.port
         connection_mode = ts.connection_mode
 

--- a/task.py
+++ b/task.py
@@ -759,6 +759,8 @@ class ServerTask(Task, ABC):
         node_name_sanitized = self.node_name_sanitized()
         port = 5201 + self.index
 
+        out_file_yaml: Optional[str] = None
+
         if connection_mode == ConnectionMode.EXTERNAL_IP:
             in_file_template = ""
             out_file_yaml = ""
@@ -767,33 +769,27 @@ class ServerTask(Task, ABC):
             ConnectionMode.MULTI_HOME,
             ConnectionMode.MULTI_NETWORK,
         ):
-            in_file_template = tftbase.get_manifest("pod-secondary-network.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"pod-secondary-network-{node_name_sanitized}-server.yaml"
-            )
+            in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = (
                 f"normal-pod-secondary-network-{node_name_sanitized}-server-{port}"
             )
         elif pod_type == PodType.SRIOV:
-            in_file_template = tftbase.get_manifest("sriov-pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"sriov-pod-{node_name_sanitized}-server.yaml"
-            )
+            in_file_template = "sriov-pod.yaml.j2"
             pod_name = f"sriov-pod-{node_name_sanitized}-server-{port}"
         elif pod_type == PodType.NORMAL:
-            in_file_template = tftbase.get_manifest("pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"pod-{node_name_sanitized}-server.yaml"
-            )
+            in_file_template = "pod.yaml.j2"
             pod_name = f"normal-pod-{node_name_sanitized}-server-{port}"
         elif pod_type == PodType.HOSTBACKED:
-            in_file_template = tftbase.get_manifest("host-pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"host-pod-{node_name_sanitized}-server.yaml"
-            )
+            in_file_template = "host-pod.yaml.j2"
             pod_name = f"host-pod-{node_name_sanitized}-server-{port}"
         else:
             raise ValueError("Invalid pod_type {pod_type}")
+
+        if in_file_template != "":
+            in_file_template = tftbase.get_manifest(in_file_template)
+
+        if out_file_yaml != "":
+            out_file_yaml = tftbase.get_manifest_renderpath(pod_name + ".yaml")
 
         self.exec_persistent = ts.node_server.is_persistent_server
         self.port = port
@@ -930,33 +926,24 @@ class ClientTask(Task, ABC):
         connection_mode = ts.connection_mode
 
         if connection_mode in (ConnectionMode.MULTI_HOME, ConnectionMode.MULTI_NETWORK):
-            in_file_template = tftbase.get_manifest("pod-secondary-network.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"pod-secondary-network-{node_name_sanitized}-client.yaml"
-            )
+            in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = (
                 f"normal-pod-secondary-network-{node_name_sanitized}-client-{port}"
             )
         elif pod_type == PodType.SRIOV:
-            in_file_template = tftbase.get_manifest("sriov-pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"sriov-pod-{node_name_sanitized}-client.yaml"
-            )
+            in_file_template = "sriov-pod.yaml.j2"
             pod_name = f"sriov-pod-{node_name_sanitized}-client-{port}"
         elif pod_type == PodType.NORMAL:
-            in_file_template = tftbase.get_manifest("pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"pod-{node_name_sanitized}-client.yaml"
-            )
+            in_file_template = "pod.yaml.j2"
             pod_name = f"normal-pod-{node_name_sanitized}-client-{port}"
         elif pod_type == PodType.HOSTBACKED:
-            in_file_template = tftbase.get_manifest("host-pod.yaml.j2")
-            out_file_yaml = tftbase.get_manifest_renderpath(
-                f"host-pod-{node_name_sanitized}-client.yaml"
-            )
+            in_file_template = "host-pod.yaml.j2"
             pod_name = f"host-pod-{node_name_sanitized}-client-{port}"
         else:
             raise ValueError("Invalid pod_type {pod_type}")
+
+        in_file_template = tftbase.get_manifest(in_file_template)
+        out_file_yaml = tftbase.get_manifest_renderpath(pod_name + ".yaml")
 
         self.server = server
         self.port = port

--- a/task.py
+++ b/task.py
@@ -377,17 +377,21 @@ class Task(ABC):
     def _get_template_args_args(self) -> list[str]:
         return []
 
+    def render_pod_file(self, log_info: str) -> None:
+        assert self.in_file_template
+        self.render_file(
+            log_info,
+            self.in_file_template,
+            self.out_file_yaml,
+        )
+
     def render_file(
         self,
         log_info: str,
-        in_file_template: Optional[str] = None,
-        out_file_yaml: Optional[str] = None,
+        in_file_template: str,
+        out_file_yaml: str,
         template_args: Optional[dict[str, str | list[str]]] = None,
     ) -> None:
-        if in_file_template is None:
-            in_file_template = self.in_file_template
-        if out_file_yaml is None:
-            out_file_yaml = self.out_file_yaml
         if template_args is None:
             template_args = self.get_template_args()
         logger.info(
@@ -808,7 +812,7 @@ class ServerTask(Task, ABC):
         assert (self.in_file_template == "") == (self.out_file_yaml == "")
 
         if self.in_file_template != "":
-            self.render_file("Server Pod Yaml")
+            self.render_pod_file("Server Pod Yaml")
 
             self.cluster_ip_addr = self.create_cluster_ip_service()
             self.nodeport_ip_addr = self.create_node_port_service(self.port + 25000)
@@ -958,7 +962,7 @@ class ClientTask(Task, ABC):
 
     def initialize(self) -> None:
         super().initialize()
-        self.render_file("Client Pod Yaml")
+        self.render_pod_file("Client Pod Yaml")
 
     def get_target_ip(self) -> str:
         if self.connection_mode == ConnectionMode.CLUSTER_IP:

--- a/testConfig.py
+++ b/testConfig.py
@@ -98,7 +98,10 @@ class ConfNodeBase(_ConfBaseConnectionItem, abc.ABC):
     ) -> T2:
         with pctx.with_strdict() as varg:
 
-            name = common.structparse_pop_str_name(varg.for_name())
+            name = common.structparse_pop_str_name(
+                varg.for_name(),
+                check=common.validate_dns_name,
+            )
 
             sriov = common.structparse_pop_bool(
                 varg.for_key("sriov"),

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -185,3 +185,24 @@ def test_get_manifest() -> None:
         tftbase.tftfile("manifests/overrides/host-pod.yaml.j2"),
     )
     assert os.path.exists(f)
+
+
+def test_str_sanitize() -> None:
+    assert tftbase.str_sanitize("") == ""
+    assert tftbase.str_sanitize("hello!wo_rld@12.3") == "hello-21-wo-5f-rld-40-12-03"
+    assert tftbase.str_sanitize("-") == "p----s"
+    assert tftbase.str_sanitize("-b") == "p---b"
+    assert tftbase.str_sanitize("foo-") == "foo---s"
+    assert tftbase.str_sanitize("f.oO-") == "f-0o-o---s"
+    assert tftbase.str_sanitize("A.B") == "p--a-0-b"
+    assert tftbase.str_sanitize("A.P") == "p--a-0-p-s"
+    assert tftbase.str_sanitize("safe123") == "p-safe123"
+    assert tftbase.str_sanitize("a-end-") == "a--end---s"
+    assert tftbase.str_sanitize("UPPER_case-") == "p--u-p-p-e-r-5f-case---s"
+    assert tftbase.str_sanitize("") == ""
+    assert tftbase.str_sanitize("-") == "p----s"
+    assert tftbase.str_sanitize("ab") == "ab"
+    assert tftbase.str_sanitize("preamble") == "p-preamble"
+    assert tftbase.str_sanitize("ends") == "ends-s"
+    assert tftbase.str_sanitize("\u03c0") == "p--3c0--s"
+    assert tftbase.str_sanitize("qs.gnrd.cAxs2.foo") == "qs-0gnrd-0c-axs2-0foo"


### PR DESCRIPTION
- ktoolbox: bump to latest version
- task: simplify selection of pod template and rename pod files
- task: add "Task.render_pod_file()" helper
- task: avoid redundant Task.out_file_yaml state
- tftbase: add str_sanitize() function for sanitizing string
- task: sanitize unusual characters in the pod name
- task: make "node_name_sanitized" a property
- testConfig: validate ConfNodeBase.name to be a valid DNS name
- manifests: quote the {node,pod}_name Jinja variables in YAML
