### PR TITLE
[th/mypy-ssl-unverified] scripts: workaround mypy error about ssl workaround

### DIFF
--- a/scripts/simple-tcp-server-client.py
+++ b/scripts/simple-tcp-server-client.py
@@ -292,7 +292,10 @@ def run_exec(
 
         # Hack up ssl._create_default_https_context so that urlretrieve()
         # ignores SSL errors.
-        ssl._create_default_https_context = ssl._create_unverified_context
+        ssl_untyped: Any = ssl
+        ssl_untyped._create_default_https_context = (
+            ssl_untyped._create_unverified_context
+        )
 
     _print(f"{log_prefix}downloading exec URL {repr(exec_url)} to {filename}")
     urllib.request.urlretrieve(exec_url, filename)


### PR DESCRIPTION
mypy doesn't like this anymore:

    scripts/simple-tcp-server-client.py:295: error: Incompatible types in assignment (expression has type "Callable[[int | None, DefaultNamedArg(int, 'cert_reqs'), DefaultNamedArg(bool, 'check_hostname'), DefaultNamedArg(Purpose, 'purpose'), DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'certfile'), DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'keyfile'), DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'cafile'), DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'capath'), DefaultNamedArg(str | Buffer | None, 'cadata')], SSLContext]", variable has type "Callable[[Purpose, DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'cafile'), DefaultNamedArg(str | bytes | PathLike[str] | PathLike[bytes] | None, 'capath'), DefaultNamedArg(str | Buffer | None, 'cadata')], SSLContext]")  [assignment]

Workaround.