### PR TITLE
tftbase: use common.getenv_config() in tftbase.get_environ()

### DIFF
--- a/tftbase.py
+++ b/tftbase.py
@@ -37,7 +37,7 @@ ENV_TFT_MANIFESTS_YAMLS = "TFT_MANIFESTS_YAMLS"
 def get_environ(name: str) -> Optional[str]:
     # Some environment variables are honored as configuration.
     # Which ones? Run `git grep -w get_environ`!
-    return os.environ.get(name, None)
+    return common.getenv_config(name)
 
 
 @functools.cache


### PR DESCRIPTION
We can set certain environment variable to modify the behavior of k8s-tft (and other variables for ktoolbox).

But how do you find which variables are supported? You might read the README, and find the information there.

Alternatively, for k8s-tft you can find them with `git grep -w get_environ`. Likewise, for ktoolbox you can find them with `git grep -w getenv_config`.

But if you know how to find them for ktoolbox, you wouldn't immediately find them for k8s-tft. This change makes that a tiny bit easier. If you now search k8s-tft for `git grep -w getenv_config`, you will find get_environ function, which leads you to the right path.