### PR TITLE
Add EgressIP support as connection mode parameter

### DIFF
--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -164,6 +164,11 @@ IPERF_TCP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -330,3 +335,8 @@ IPERF_UDP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/manifests/egressip.yaml.j2
+++ b/manifests/egressip.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: {{ egressip_name }}
+  labels:
+    tft-tests: {{ label_tft_tests }}
+spec:
+  egressIPs:
+{{ egress_ips_yaml }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ name_space }}

--- a/task.py
+++ b/task.py
@@ -1,4 +1,5 @@
 import enum
+import ipaddress
 import json
 import logging
 import os
@@ -829,6 +830,63 @@ class Task(ABC):
 
         return None
 
+    def create_egressip(self, egress_ip: str, egress_node: str) -> str:
+        """Set up EgressIP: validate, label node, and create EgressIP CR.
+
+        Validates the egress node exists and the IP is in its subnet,
+        labels the node as egress-assignable, and applies the EgressIP CR.
+        """
+        # Validate egress node exists
+        self.run_oc(f"get node {egress_node}", namespace=None, die_on_error=True)
+
+        # Validate egress IP is in the node's subnet
+        result = self.run_oc(
+            f"get node {egress_node} -o jsonpath='{{.metadata.annotations.k8s\\.ovn\\.org/node-primary-ifaddr}}'",
+            namespace=None,
+            die_on_error=True,
+        )
+        ifaddr = json.loads(result.out.strip().strip("'\""))
+        if "ipv4" not in ifaddr:
+            raise RuntimeError(
+                f"Node {egress_node} has no ipv4 entry in node-primary-ifaddr annotation"
+            )
+        network = ipaddress.ip_network(ifaddr["ipv4"], strict=False)
+        if ipaddress.ip_address(egress_ip) not in network:
+            raise ValueError(
+                f"EgressIP '{egress_ip}' is not in node network '{network}'"
+            )
+        logger.info(f"Validated egress IP {egress_ip} is in node network {network}")
+
+        # Label the node as egress-assignable
+        self.run_oc(
+            f"label node {egress_node} k8s.ovn.org/egress-assignable=true --overwrite",
+            namespace=None,
+            die_on_error=True,
+        )
+
+        # Render and apply the EgressIP CR
+        egressip_name = f"egressip-{tftbase.str_sanitize(egress_node)}"
+        in_file_template = tftbase.get_manifest("egressip.yaml.j2")
+        out_file_yaml = tftbase.get_manifest_renderpath(f"{egressip_name}.yaml")
+
+        template_args = {
+            **self.get_template_args(),
+            "egressip_name": f'"{egressip_name}"',
+            "egress_ips_yaml": f"      - {egress_ip}",
+        }
+
+        self.render_file("EgressIP CR", in_file_template, out_file_yaml, template_args)
+        self.run_oc(
+            f"apply -f {out_file_yaml}",
+            namespace=None,
+            die_on_error=True,
+        )
+        return self.run_oc(
+            f"get egressip {egressip_name}",
+            namespace=None,
+            die_on_error=True,
+        ).out
+
 
 class ServerTask(Task, ABC):
     def __init__(self, ts: TestSettings):
@@ -1139,6 +1197,15 @@ class ClientTask(Task, ABC):
         super().initialize()
         self.render_pod_file("Client Pod Yaml")
 
+        # Set up EgressIP if configured
+        conn = self.ts.connection
+        if conn.has_egress_ip:
+            assert conn.egress_ip is not None
+            self.create_egressip(
+                conn.egress_ip.ip,
+                conn.get_effective_egress_node(self.ts.node_client.name),
+            )
+
     def get_target_ip(self) -> str:
         if self.connection_mode == ConnectionMode.CLUSTER_IP:
             logger.debug(
@@ -1151,6 +1218,12 @@ class ClientTask(Task, ABC):
             )
             return self.server.nodeport_ip_addr
         elif self.connection_mode == ConnectionMode.EXTERNAL_IP:
+            external_server_ip = self.ts.connection.external_server_ip
+            if external_server_ip is not None:
+                logger.debug(
+                    f"get_target_ip() External connection to configured server {external_server_ip}"
+                )
+                return external_server_ip
             # For port forwarding, connect to the host's IP, not the container's internal IP
             host_ip = self.get_host_ip()
             logger.debug(f"get_target_ip() External connection to host {host_ip}")

--- a/testConfig.py
+++ b/testConfig.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import datetime
+import ipaddress
 import json
 import logging
 import os
@@ -309,6 +310,51 @@ class ConfNodeClient(ConfNodeBase):
 
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
+class ConfEgressIP(StructParseBase):
+    ip: str
+    node: Optional[str]
+
+    def serialize(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"ip": self.ip}
+        common.dict_add_optional(d, "node", self.node)
+        return d
+
+    @staticmethod
+    def parse(pctx: StructParseParseContext) -> "ConfEgressIP":
+        with pctx.with_strdict() as varg:
+
+            def _validate_ip(pctx2: StructParseParseContext) -> str:
+                ip_str = pctx2.arg
+                if not isinstance(ip_str, str):
+                    raise pctx2.value_error("ip must be a string")
+                try:
+                    ipaddress.ip_address(ip_str)
+                except ValueError as e:
+                    raise pctx2.value_error(
+                        f"ip '{ip_str}' is not a valid IP address: {e}"
+                    )
+                return ip_str
+
+            ip = common.structparse_pop_obj(
+                varg.for_key("ip"),
+                construct=_validate_ip,
+            )
+
+            node = common.structparse_pop_str(
+                varg.for_key("node"),
+                default=None,
+            )
+
+        return ConfEgressIP(
+            yamlidx=pctx.yamlidx,
+            yamlpath=pctx.yamlpath,
+            ip=ip,
+            node=node,
+        )
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
 class ConfConnection(StructParseBaseNamed):
     test_type: TestType
     test_type_handler: TestTypeHandler
@@ -319,6 +365,12 @@ class ConfConnection(StructParseBaseNamed):
     plugins: tuple[ConfPlugin, ...]
     secondary_network_nad: Optional[str]
     resource_name: Optional[str]
+
+    # EgressIP configuration (nested object)
+    egress_ip: Optional[ConfEgressIP]
+
+    # External server IP for POD_TO_EXTERNAL_EGRESS test cases
+    external_server_ip: Optional[str]
 
     # This parameter is not expressed in YAML. It gets passed by the parent to
     # ConfConnection.parse()
@@ -336,12 +388,26 @@ class ConfConnection(StructParseBaseNamed):
     def tft(self) -> "ConfTest":
         return self._owner_reference.get(ConfTest)
 
+    @property
+    def has_egress_ip(self) -> bool:
+        """Returns True if egress_ip is configured."""
+        return self.egress_ip is not None
+
+    def get_effective_egress_node(self, client_node_name: str) -> str:
+        """Returns egress_node if configured, otherwise defaults to client node."""
+        if self.egress_ip is not None and self.egress_ip.node is not None:
+            return self.egress_ip.node
+        return client_node_name
+
     def serialize(self) -> dict[str, Any]:
         extra: dict[str, Any] = {}
         common.dict_add_optional(
             extra, "secondary_network_nad", self.secondary_network_nad
         )
         common.dict_add_optional(extra, "resource_name", self.resource_name)
+        if self.egress_ip is not None:
+            extra["egress_ip"] = self.egress_ip.serialize()
+        common.dict_add_optional(extra, "external_server_ip", self.external_server_ip)
         return {
             **super().serialize(),
             "type": self.test_type.name,
@@ -425,6 +491,33 @@ class ConfConnection(StructParseBaseNamed):
                 default=None,
             )
 
+            # EgressIP configuration (nested object)
+            egress_ip = common.structparse_pop_obj(
+                varg.for_key("egress_ip"),
+                construct=ConfEgressIP.parse,
+                default=None,
+            )
+
+            def _validate_external_server_ip(
+                pctx2: StructParseParseContext,
+            ) -> str:
+                ip_str = pctx2.arg
+                if not isinstance(ip_str, str):
+                    raise pctx2.value_error("external_server_ip must be a string")
+                try:
+                    ipaddress.ip_address(ip_str)
+                except ValueError as e:
+                    raise pctx2.value_error(
+                        f"external_server_ip '{ip_str}' is not a valid IP address: {e}"
+                    )
+                return ip_str
+
+            external_server_ip = common.structparse_pop_obj(
+                varg.for_key("external_server_ip"),
+                construct=_validate_external_server_ip,
+                default=None,
+            )
+
         if len(server) > 1:
             raise pctx.value_error(
                 "currently only one server entry is supported", key="server"
@@ -454,6 +547,8 @@ class ConfConnection(StructParseBaseNamed):
             plugins=plugins,
             secondary_network_nad=secondary_network_nad,
             resource_name=resource_name,
+            egress_ip=egress_ip,
+            external_server_ip=external_server_ip,
             namespace=namespace,
         )
 

--- a/tests/eval-config-2.yaml
+++ b/tests/eval-config-2.yaml
@@ -164,6 +164,11 @@ IPERF_TCP:
   Reverse:
     threshold: 10
   id: 33
+- Normal:
+    threshold: 20
+  Reverse:
+    threshold: 11
+  id: 34
 IPERF_UDP:
 - Normal:
     threshold: 5
@@ -330,3 +335,8 @@ IPERF_UDP:
   Reverse:
     threshold: 5
   id: 33
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 34

--- a/tests/generate-eval-config-output0.yaml
+++ b/tests/generate-eval-config-output0.yaml
@@ -164,6 +164,11 @@ IPERF_TCP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -330,3 +335,8 @@ IPERF_UDP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/tests/generate-eval-config-output2.yaml
+++ b/tests/generate-eval-config-output2.yaml
@@ -201,6 +201,11 @@ IPERF_TCP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -367,3 +372,8 @@ IPERF_UDP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/tests/generate-eval-config-output3.yaml
+++ b/tests/generate-eval-config-output3.yaml
@@ -185,6 +185,11 @@ IPERF_TCP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -351,3 +356,8 @@ IPERF_UDP:
       threshold: 0
     Reverse:
       threshold: 0
+  - id: POD_TO_EXTERNAL_EGRESS
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -292,3 +292,150 @@ tft:
     assert tc.config.tft[0].get_output_file() == pathlib.Path("/tmp/result2-000.json")
 
     _check_testConfig(tc)
+
+
+def test_egress_ip_config() -> None:
+    # Test basic egress_ip parsing with ip only
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: egress-test
+      type: iperf-tcp
+      egress_ip:
+        ip: "10.0.0.100"
+      external_server_ip: "192.168.1.1"
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    tc = testConfig.TestConfig(
+        full_config=full_config,
+        kubeconfigs=testConfigKubeconfigsArgs1,
+    )
+    conn = tc.config.tft[0].connections[0]
+    assert conn.has_egress_ip is True
+    assert conn.egress_ip is not None
+    assert conn.egress_ip.ip == "10.0.0.100"
+    assert conn.egress_ip.node is None
+    assert conn.external_server_ip == "192.168.1.1"
+
+    # get_effective_egress_node defaults to client node when node is None
+    assert conn.get_effective_egress_node("client1") == "client1"
+
+    _check_testConfig(tc)
+
+
+def test_egress_ip_config_with_node() -> None:
+    # Test egress_ip parsing with explicit node
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: egress-test
+      type: iperf-tcp
+      egress_ip:
+        ip: "10.0.0.100"
+        node: "egress-node-1"
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    tc = testConfig.TestConfig(
+        full_config=full_config,
+        kubeconfigs=testConfigKubeconfigsArgs1,
+    )
+    conn = tc.config.tft[0].connections[0]
+    assert conn.egress_ip is not None
+    assert conn.egress_ip.ip == "10.0.0.100"
+    assert conn.egress_ip.node == "egress-node-1"
+
+    # get_effective_egress_node uses configured node
+    assert conn.get_effective_egress_node("client1") == "egress-node-1"
+
+    _check_testConfig(tc)
+
+
+def test_egress_ip_not_configured() -> None:
+    # Test that egress_ip defaults to None when not specified
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: basic-test
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    tc = testConfig.TestConfig(
+        full_config=full_config,
+        kubeconfigs=testConfigKubeconfigsArgs1,
+    )
+    conn = tc.config.tft[0].connections[0]
+    assert conn.has_egress_ip is False
+    assert conn.egress_ip is None
+    assert conn.external_server_ip is None
+
+    _check_testConfig(tc)
+
+
+def test_egress_ip_invalid_ip() -> None:
+    # Test that invalid IP address is rejected
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: egress-test
+      type: iperf-tcp
+      egress_ip:
+        ip: "not-an-ip"
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    with pytest.raises(ValueError, match="not a valid IP address"):
+        testConfig.TestConfig(
+            full_config=full_config,
+            kubeconfigs=testConfigKubeconfigsArgs1,
+        )
+
+
+def test_egress_ip_missing_ip() -> None:
+    # Test that egress_ip without ip field is rejected
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: egress-test
+      type: iperf-tcp
+      egress_ip:
+        node: "some-node"
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    with pytest.raises(ValueError):
+        testConfig.TestConfig(
+            full_config=full_config,
+            kubeconfigs=testConfigKubeconfigsArgs1,
+        )
+
+
+def test_external_server_ip_invalid() -> None:
+    # Test that invalid external_server_ip is rejected
+    full_config = yaml.safe_load("""
+tft:
+  - connections:
+    - name: egress-test
+      type: iperf-tcp
+      external_server_ip: "not-an-ip"
+      server:
+        - name: server1
+      client:
+        - name: client1
+""")
+    with pytest.raises(ValueError, match="not a valid IP address"):
+        testConfig.TestConfig(
+            full_config=full_config,
+            kubeconfigs=testConfigKubeconfigsArgs1,
+        )

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -129,7 +129,7 @@ def test_test_case_typ_infos() -> None:
         assert ti.test_case_type is typ
         assert typ.info is ti
 
-    assert list(TestCaseType)[-1].value == 33
+    assert list(TestCaseType)[-1].value == 34
     list_numeric = list(range(1, list(TestCaseType)[-1].value + 1))
     assert list_numeric == [typ.value for typ in tftbase.TestCaseType]
 
@@ -143,9 +143,19 @@ def test_test_case_typ_infos() -> None:
             and ti1.expects_blocked == ti2.expects_blocked
         )
 
+    # POD_TO_EXTERNAL_EGRESS intentionally shares the same topology as
+    # POD_TO_EXTERNAL (same connection_mode, node placement, hostbacking).
+    # The difference is that it applies an EgressIP, which is not captured
+    # in the TestCaseTypInfo fields checked here.
+    _allowed_identical_pairs = {
+        frozenset({TestCaseType.POD_TO_EXTERNAL, TestCaseType.POD_TO_EXTERNAL_EGRESS}),
+    }
+
     for idx1, ti1 in enumerate(test_case_typ_infos):
         for idx2, ti2 in enumerate(test_case_typ_infos[idx1 + 1 :]):
-            assert not _is_identical(ti1, ti2)
+            if _is_identical(ti1, ti2):
+                pair = frozenset({ti1.test_case_type, ti2.test_case_type})
+                assert pair in _allowed_identical_pairs
     for idx1, ti1 in enumerate(test_case_typ_infos):
         assert (
             ti1.test_case_type == (list(TestCaseType))[idx1]

--- a/tftbase.py
+++ b/tftbase.py
@@ -329,6 +329,7 @@ class TestCaseType(Enum):
     POD_TO_POD_ANP_ALLOW = 31
     POD_TO_POD_ANP_DENY = 32
     POD_TO_POD_ANP_PASS_NP_DENY = 33
+    POD_TO_EXTERNAL_EGRESS = 34
 
     @property
     def info(self) -> "TestCaseTypInfo":
@@ -1033,6 +1034,13 @@ _test_case_typ_infos = {
             is_server_hostbacked=False,
             is_client_hostbacked=False,
             expects_blocked=True,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.POD_TO_EXTERNAL_EGRESS,
+            connection_mode=ConnectionMode.EXTERNAL_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
         ),
     )
 }

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -76,6 +76,28 @@ class TrafficFlowTests:
             ),
         )
 
+        # Clean up EgressIP CRs with tft-tests label (cluster-scoped)
+        client.oc(
+            "delete egressip -l tft-tests",
+            namespace=None,
+            check_success=client.check_success_delete_ignore_noexist("egressip"),
+        )
+
+        # Remove egress-assignable label from any nodes that have it
+        result = client.oc(
+            "get nodes -l k8s.ovn.org/egress-assignable -o jsonpath='{.items[*].metadata.name}'",
+            namespace=None,
+            may_fail=True,
+        )
+        if result.success and result.out.strip().strip("'\""):
+            for node_name in result.out.strip().strip("'\"").split():
+                logger.info(f"Removing egress-assignable label from node {node_name}")
+                client.oc(
+                    f"label node {node_name} k8s.ovn.org/egress-assignable-",
+                    namespace=None,
+                    may_fail=True,
+                )
+
         logger.info(
             f"Cleaning external containers {task.EXTERNAL_PERF_SERVER} (if present)"
         )


### PR DESCRIPTION
## Summary
- Add `POD_TO_EXTERNAL_EGRESS` test case type for EgressIP testing
- Add `egress_ip` as a connection parameter with IP validation and optional node selection
- Add `create_egressip()` to Task class following the ANP resource creation pattern
- Add EgressIP CR and node label cleanup in `_cleanup_previous_testspace()`

### Usage
```yaml
connections:
  - name: "test"
    type: iperf-tcp
    egress_ip:
      ip: "192.168.1.100"
      node: "worker-1"  # optional, defaults to client node
    external_server_ip: "10.0.0.1"  # optional
```

## Test plan
- [x] Unit tests pass (`pytest` — 42 tests)
- [x] Pre-commit hooks pass (black, flake8, mypy)
- [x] Verified with live EgressIP test against OVN-Kubernetes cluster
- [x] Rebased onto origin/main
- [x] Addressed review feedback:
  - Removed egress-specific properties from `testSettings.py`
  - Consolidated 6 helper methods into single `create_egressip()` matching ANP pattern
  - Decoupled from DPU — uses `self.run_oc()` throughout
  - CR and node label cleanup confirmed in `trafficFlowTests.py`