### PR TITLE
Add UDN secondary service and localnet test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ tft:
             secondary_network_nad: "(19)"
         plugins:
           - name: (20)
-            test_cases: (20a)
+            test_cases: (21)
           - name: (20)
-        secondary_network_nad: "(21)"
-        resource_name: "(22)"
-        cpu_request: "(23)"
-        cpu_limit: "(24)"
-        mem_request: "(25)"
-        mem_limit: "(26)"
-    privileged_pod: (27)
-    capabilities_pod: (28)
-kubeconfig: (29)
-kubeconfig_infra: (29)
+        secondary_network_nad: "(22)"
+        resource_name: "(23)"
+        cpu_request: "(24)"
+        cpu_limit: "(25)"
+        mem_request: "(26)"
+        mem_limit: "(27)"
+    privileged_pod: (28)
+    capabilities_pod: (29)
+kubeconfig: (30)
+kubeconfig_infra: (30)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -131,14 +131,24 @@ kubeconfig_infra: (29)
     | 42 | UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
     | 43 | UDN_SECONDARY_POD_TO_POD_SAME_NODE |
     | 44 | UDN_SECONDARY_POD_TO_POD_DIFF_NODE |
-    | 45 | POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
-    | 46 | POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
-    | 47 | POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
-    | 48 | POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
-    | 49 | HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
-    | 50 | HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
-    | 51 | HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
-    | 52 | HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
+    | 45 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
+    | 46 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
+    | 47 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
+    | 48 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
+    | 49 | UDN_LOCALNET_POD_TO_POD_SAME_NODE |
+    | 50 | UDN_LOCALNET_POD_TO_POD_DIFF_NODE |
+    | 51 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
+    | 52 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
+    | 53 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
+    | 54 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
+    | 55 | POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
+    | 56 | POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
+    | 57 | POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
+    | 58 | POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
+    | 59 | HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
+    | 60 | HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
+    | 61 | HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
+    | 62 | HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
 4. "duration" - The duration that each individual test will run for.
 5. "pre_provision" - (Optional) Whether to pre-provision all pods and services once before the test run begins, rather than creating and tearing them down per test case. Defaults to false. Takes in "true/false".
 6. "name" - This is the connection name. Any string value to identify the connection.
@@ -164,20 +174,19 @@ kubeconfig_infra: (29)
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
-20a. "test_cases" - (Optional) Restrict a plugin to run only for the specified test cases. Uses the same format as the top-level `test_cases` field. By default, the plugin runs for every test case.
-21. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-31, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-31 it defaults to "tft-secondary" if not set. Can be overridden per-node using the server/client level `secondary_network_nad` fields. The framework automatically creates and cleans up the NAD when these test cases are selected or when SRIOV nodes reference a secondary NAD. Subnets, MTU, and topology default to `10.193.0.0/16/26`, `1500`, and `layer3`, overridable via `TFT_SECONDARY_NAD_SUBNETS`, `TFT_SECONDARY_NAD_MTU`, and `TFT_SECONDARY_NAD_TOPOLOGY`.
-22. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test
-tool will try to autopopulate resource_name based on the secondary+network_nad provided.
-23. "cpu_request" - (Optional) CPU request for server and client pods (e.g. "10m", "500m"). No CPU request is set if omitted.
-24. "cpu_limit" - (Optional) CPU limit for server and client pods (e.g. "20m", "1000m"). No CPU limit is set if omitted.
-25. "mem_request" - (Optional) Memory request for server and client pods (e.g. "50Mi", "100Mi"). No memory request is set if omitted.
-26. "mem_limit" - (Optional) Memory limit for server and client pods (e.g. "100Mi", "200Mi"). No memory limit is set if omitted.
-27. "privileged_pod" - (Optional) - Whether to run test pods as privileged. Defaults to false. Can be set at test level or per-node (server/client).
-28. "capabilities_pod" - (Optional) - Linux capabilities for test pods. Format: `{"add": ["NET_ADMIN", "SYS_TIME"]}`. Can be set at test level (applies to all pods) or per-node (server/client) for fine-grained control. Per-node settings take precedence over test-level settings.
-29. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+21. "test_cases" - (Optional) Restrict a plugin to run only for the specified test cases. Uses the same format as the top-level `test_cases` field. By default, the plugin runs for every test case.
+22. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-31, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-31 it defaults to "tft-secondary" if not set. Can be overridden per-node using the server/client level `secondary_network_nad` fields. The framework automatically creates and cleans up the NAD when these test cases are selected or when SRIOV nodes reference a secondary NAD. Subnets, MTU, and topology default to `10.193.0.0/16/26`, `1500`, and `layer3`, overridable via `TFT_SECONDARY_NAD_SUBNETS`, `TFT_SECONDARY_NAD_MTU`, and `TFT_SECONDARY_NAD_TOPOLOGY`.
+23. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test tool will try to autopopulate resource_name based on the secondary+network_nad provided.
+24. "cpu_request" - (Optional) CPU request for server and client pods (e.g. "10m", "500m"). No CPU request is set if omitted.
+25. "cpu_limit" - (Optional) CPU limit for server and client pods (e.g. "20m", "1000m"). No CPU limit is set if omitted.
+26. "mem_request" - (Optional) Memory request for server and client pods (e.g. "50Mi", "100Mi"). No memory request is set if omitted.
+27. "mem_limit" - (Optional) Memory limit for server and client pods (e.g. "100Mi", "200Mi"). No memory limit is set if omitted.
+28. "privileged_pod" - (Optional) - Whether to run test pods as privileged. Defaults to false. Can be set at test level or per-node (server/client).
+29. "capabilities_pod" - (Optional) - Linux capabilities for test pods. Format: `{"add": ["NET_ADMIN", "SYS_TIME"]}`. Can be set at test level (applies to all pods) or per-node (server/client) for fine-grained control. Per-node settings take precedence over test-level settings.
+30. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
-30. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
+31. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
   which host worker node they belong to. For NVIDIA DPUs, use `provisioning.dpu.nvidia.com/host`.
 
 
@@ -185,12 +194,13 @@ tool will try to autopopulate resource_name based on the secondary+network_nad p
 
 See the [OVN-Kubernetes UDN documentation](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/user-defined-networks.md) for details on User Defined Networks.
 
-Test cases 34-41 run traffic over OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically.
+Test cases 37-54 run traffic over OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically.
 
-- **34-39** (Primary UDN): Layer3 network replacing the pod's default network.
-- **40-41** (Secondary UDN): Layer2 network attached as a 2nd interface.
+- **37-42** (Primary UDN): Layer3 network replacing the pod's default network. Supports pod-to-pod, ClusterIP, and NodePort.
+- **43-48** (Secondary UDN): Layer2 network attached as a 2nd interface. Supports pod-to-pod, ClusterIP, and NodePort.
+- **49-54** (Localnet UDN): Localnet topology secondary network via ClusterUserDefinedNetwork, providing direct L2 access. Supports pod-to-pod, ClusterIP, and NodePort.
 
-CIDRs default to `15.1.0.0/16` / `15.2.0.0/16`, overridable via `TFT_UDN_PRIMARY_CIDR` and `TFT_UDN_SECONDARY_CIDR`. Reference manifests are in `manifests/udn-primary.yaml.j2` and `manifests/udn-secondary.yaml.j2`.
+CIDRs default to `15.1.0.0/16` (primary), `15.2.0.0/16` (secondary), and `15.3.0.0/24` (localnet), overridable via `TFT_UDN_PRIMARY_CIDR`, `TFT_UDN_SECONDARY_CIDR`, and `TFT_UDN_LOCALNET_CIDR`. The localnet physical network name defaults to `physnet`, overridable via `TFT_UDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn-primary.yaml.j2`, `manifests/udn-secondary.yaml.j2`, and `manifests/udn-localnet.yaml.j2`.
 
 ## DPU Mode
 
@@ -356,6 +366,10 @@ tft:
      defaults to "manifests/yamls".
 - `TFT_KUBECONFIG`, `TFT_KUBECONFIG_INFRA` to overwrite the kubeconfigs from the configuration
      file. See also the "--kubeconfig" and "--kubeconfig-infra" command line options.
+- `TFT_UDN_PRIMARY_CIDR` CIDR for primary UDN tests. Defaults to `15.1.0.0/16`.
+- `TFT_UDN_SECONDARY_CIDR` CIDR for secondary UDN tests. Defaults to `15.2.0.0/16`.
+- `TFT_UDN_LOCALNET_CIDR` CIDR for localnet UDN tests. Defaults to `15.3.0.0/24`.
+- `TFT_UDN_LOCALNET_PHYSICAL_NETWORK` physical network name for localnet UDN tests. Defaults to `physnet`.
 - `TFT_EXTERNAL_URL` URL to curl for external connectivity tests (e.g. `http://google.com`).
      Only effective when the connection type is `http` and the connection mode is `POD_TO_EXTERNAL`
      or `HOST_TO_EXTERNAL`. When set, no Podman server is started; the client pod curls this URL

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -219,6 +219,56 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -476,6 +526,56 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_SECONDARY_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/manifests/udn-localnet.yaml.j2
+++ b/manifests/udn-localnet.yaml.j2
@@ -1,0 +1,22 @@
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: tft-localnet
+  labels:
+    tft-tests: "udn"{% if has_resource_name %}
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: {{ resource_name }}{% endif %}
+spec:
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - {{ name_space }}
+  network:
+    topology: Localnet
+    localnet:
+      role: Secondary
+      physicalNetworkName: {{ physical_network_name }}
+      subnets:
+      - {{ localnet_cidr }}

--- a/task.py
+++ b/task.py
@@ -400,7 +400,9 @@ class Task(ABC):
         return tftbase.get_tft_test_image_for_type(self.ts.connection.test_type)
 
     def _get_effective_secondary_network_nad(self) -> str:
-        if self.ts.test_case_id.is_udn:
+        if self.ts.test_case_id.is_udn_localnet:
+            return f"{self.get_namespace()}/tft-localnet"
+        if self.ts.test_case_id.is_udn_secondary:
             return f"{self.get_namespace()}/tft-secondary"
         nad = self._get_node_secondary_network_nad()
         if nad is not None:
@@ -441,6 +443,7 @@ class Task(ABC):
                 bool(self._get_node_secondary_network_nad())
                 or bool(self.ts.connection.secondary_network_nad)
                 or self.ts.test_case_id.is_udn_secondary
+                or self.ts.test_case_id.is_udn_localnet
             ),
             "has_resource_name": bool(resource_name),
             "resource_name": _j(resource_name),
@@ -482,7 +485,13 @@ class Task(ABC):
 
     @property
     def _network_type(self) -> str:
-        return "secondary" if self.ts.connection_mode in _SECONDARY_MODES else "primary"
+        if (
+            self.ts.connection_mode in _SECONDARY_MODES
+            or self.ts.test_case_id.is_udn_secondary
+            or self.ts.test_case_id.is_udn_localnet
+        ):
+            return "secondary"
+        return "primary"
 
     def render_pod_file(self, log_info: str) -> None:
         self.render_file(
@@ -1106,11 +1115,9 @@ class ServerTask(Task, ABC):
         elif connection_mode == ConnectionMode.EXTERNAL_IP:
             in_file_template = ""
             pod_name = EXTERNAL_PERF_SERVER
-        elif connection_mode in (
-            ConnectionMode.MULTI_HOME,
-            ConnectionMode.MNP_2ND_DENY,
-            ConnectionMode.MNP_2ND_ALLOW,
-            ConnectionMode.MNP_PRIMARY_DENY,
+        elif (
+            self._network_type == "secondary"
+            or connection_mode == ConnectionMode.MNP_PRIMARY_DENY
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = f"normal-pod-secondary-server-{port}"
@@ -1415,11 +1422,9 @@ class ClientTask(Task, ABC):
         port = server.port
         connection_mode = ts.connection_mode
 
-        if connection_mode in (
-            ConnectionMode.MULTI_HOME,
-            ConnectionMode.MNP_2ND_DENY,
-            ConnectionMode.MNP_2ND_ALLOW,
-            ConnectionMode.MNP_PRIMARY_DENY,
+        if (
+            self._network_type == "secondary"
+            or connection_mode == ConnectionMode.MNP_PRIMARY_DENY
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = f"normal-pod-secondary-{node_location}-client"

--- a/tests/eval-config-2.yaml
+++ b/tests/eval-config-2.yaml
@@ -259,6 +259,56 @@ IPERF_TCP:
   Reverse:
     threshold: 10
   id: 52
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 53
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 54
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 55
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 56
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 57
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 58
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 59
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 60
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 61
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 62
 IPERF_UDP:
 - Normal:
     threshold: 5
@@ -520,3 +570,53 @@ IPERF_UDP:
   Reverse:
     threshold: 5
   id: 52
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 53
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 54
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 55
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 56
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 57
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 58
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 59
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 60
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 61
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 62

--- a/tests/generate-eval-config-output0.yaml
+++ b/tests/generate-eval-config-output0.yaml
@@ -219,6 +219,56 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -476,6 +526,56 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_SECONDARY_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/generate-eval-config-output2.yaml
+++ b/tests/generate-eval-config-output2.yaml
@@ -256,6 +256,56 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -519,6 +569,56 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_SECONDARY_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/generate-eval-config-output3.yaml
+++ b/tests/generate-eval-config-output3.yaml
@@ -240,6 +240,56 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -497,6 +547,56 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_SECONDARY_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -129,23 +129,30 @@ def test_test_case_typ_infos() -> None:
         assert ti.test_case_type is typ
         assert typ.info is ti
 
-    assert list(TestCaseType)[-1].value == 52
+    assert list(TestCaseType)[-1].value == 62
     list_numeric = list(range(1, list(TestCaseType)[-1].value + 1))
     assert list_numeric == [typ.value for typ in tftbase.TestCaseType]
 
     for typ in TestCaseType:
-        if typ.is_udn_primary or typ.is_udn_secondary:
+        if typ.is_udn_primary or typ.is_udn_secondary or typ.is_udn_localnet:
             assert typ.is_udn
         if typ.is_udn:
-            assert typ.is_udn_primary or typ.is_udn_secondary
-        assert not (typ.is_udn_primary and typ.is_udn_secondary)
+            assert typ.is_udn_primary or typ.is_udn_secondary or typ.is_udn_localnet
+        assert sum([typ.is_udn_primary, typ.is_udn_secondary, typ.is_udn_localnet]) <= 1
 
     def _is_identical(ti1: TestCaseTypInfo, ti2: TestCaseTypInfo) -> bool:
         assert ti1.test_case_type != ti2.test_case_type
-        is_udn1 = ti1.test_case_type.is_udn
-        is_udn2 = ti2.test_case_type.is_udn
-        if is_udn1 != is_udn2:
+        t1 = ti1.test_case_type
+        t2 = ti2.test_case_type
+        if t1.is_udn != t2.is_udn:
             return False
+        if t1.is_udn:
+            if t1.is_udn_primary != t2.is_udn_primary:
+                return False
+            if t1.is_udn_secondary != t2.is_udn_secondary:
+                return False
+            if t1.is_udn_localnet != t2.is_udn_localnet:
+                return False
         return (
             ti1.connection_mode == ti2.connection_mode
             and ti1.is_same_node == ti2.is_same_node

--- a/tftbase.py
+++ b/tftbase.py
@@ -183,6 +183,8 @@ TFT_TESTS = "tft-tests"
 
 ENV_TFT_UDN_PRIMARY_CIDR = "TFT_UDN_PRIMARY_CIDR"
 ENV_TFT_UDN_SECONDARY_CIDR = "TFT_UDN_SECONDARY_CIDR"
+ENV_TFT_UDN_LOCALNET_CIDR = "TFT_UDN_LOCALNET_CIDR"
+ENV_TFT_UDN_LOCALNET_PHYSICAL_NETWORK = "TFT_UDN_LOCALNET_PHYSICAL_NETWORK"
 
 ENV_TFT_SECONDARY_NAD_SUBNETS = "TFT_SECONDARY_NAD_SUBNETS"
 ENV_TFT_SECONDARY_NAD_MTU = "TFT_SECONDARY_NAD_MTU"
@@ -200,6 +202,20 @@ def get_udn_primary_cidr() -> str:
 def get_udn_secondary_cidr() -> str:
     s = get_environ(ENV_TFT_UDN_SECONDARY_CIDR) or "15.2.0.0/16"
     logger.info(f"env: {ENV_TFT_UDN_SECONDARY_CIDR}={shlex.quote(s)}")
+    return s
+
+
+@functools.cache
+def get_udn_localnet_cidr() -> str:
+    s = get_environ(ENV_TFT_UDN_LOCALNET_CIDR) or "15.3.0.0/24"
+    logger.info(f"env: {ENV_TFT_UDN_LOCALNET_CIDR}={shlex.quote(s)}")
+    return s
+
+
+@functools.cache
+def get_udn_localnet_physical_network() -> str:
+    s = get_environ(ENV_TFT_UDN_LOCALNET_PHYSICAL_NETWORK) or "physnet"
+    logger.info(f"env: {ENV_TFT_UDN_LOCALNET_PHYSICAL_NETWORK}={shlex.quote(s)}")
     return s
 
 
@@ -399,14 +415,24 @@ class TestCaseType(Enum):
     UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 42
     UDN_SECONDARY_POD_TO_POD_SAME_NODE = 43
     UDN_SECONDARY_POD_TO_POD_DIFF_NODE = 44
-    POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 45
-    POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 46
-    POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 47
-    POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 48
-    HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 49
-    HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 50
-    HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 51
-    HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 52
+    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 45
+    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 46
+    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 47
+    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 48
+    UDN_LOCALNET_POD_TO_POD_SAME_NODE = 49
+    UDN_LOCALNET_POD_TO_POD_DIFF_NODE = 50
+    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 51
+    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 52
+    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 53
+    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 54
+    POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 55
+    POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 56
+    POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 57
+    POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 58
+    HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 59
+    HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 60
+    HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 61
+    HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 62
 
     @property
     def is_udn(self) -> bool:
@@ -419,6 +445,10 @@ class TestCaseType(Enum):
     @property
     def is_udn_secondary(self) -> bool:
         return self.name.startswith("UDN_SECONDARY_")
+
+    @property
+    def is_udn_localnet(self) -> bool:
+        return self.name.startswith("UDN_LOCALNET_")
 
     @property
     def info(self) -> "TestCaseTypInfo":
@@ -1204,6 +1234,76 @@ _test_case_typ_infos = {
         TestCaseTypInfo(
             test_case_type=TestCaseType.UDN_SECONDARY_POD_TO_POD_DIFF_NODE,
             connection_mode=ConnectionMode.MULTI_HOME,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.CLUSTER_IP,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.CLUSTER_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.NODE_PORT_IP,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.NODE_PORT_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.MULTI_HOME,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.MULTI_HOME,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.CLUSTER_IP,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.CLUSTER_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.NODE_PORT_IP,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.NODE_PORT_IP,
             is_same_node=False,
             is_server_hostbacked=False,
             is_client_hostbacked=False,

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -58,8 +58,9 @@ class TrafficFlowTests:
         tft = cfg_descr.get_tft()
         needs_primary = any(tc.is_udn_primary for tc in tft.test_cases)
         needs_secondary = any(tc.is_udn_secondary for tc in tft.test_cases)
+        needs_localnet = any(tc.is_udn_localnet for tc in tft.test_cases)
 
-        if not needs_primary and not needs_secondary:
+        if not needs_primary and not needs_secondary and not needs_localnet:
             return
 
         udn_ns = f"{tft.namespace}-udn"
@@ -116,6 +117,9 @@ class TrafficFlowTests:
                 },
                 out_file=out_yaml,
             )
+            logger.info(
+                f'Generate Primary UDN Yaml "{out_yaml}" (from "{in_template}")'
+            )
             client.oc(f"apply -f {out_yaml}", die_on_error=True)
 
         if needs_secondary:
@@ -131,7 +135,31 @@ class TrafficFlowTests:
                 },
                 out_file=out_yaml,
             )
+            logger.info(
+                f'Generate Secondary UDN Yaml "{out_yaml}" (from "{in_template}")'
+            )
             client.oc(f"apply -f {out_yaml}", die_on_error=True)
+
+        if needs_localnet:
+            in_template = tftbase.get_manifest("udn-localnet.yaml.j2")
+            out_yaml = tftbase.get_manifest_renderpath("udn-localnet.yaml")
+            kjinja2.render_file(
+                in_template,
+                {
+                    "has_resource_name": resource_name is not None,
+                    "resource_name": resource_name or "",
+                    "name_space": _j(udn_ns),
+                    "localnet_cidr": _j(tftbase.get_udn_localnet_cidr()),
+                    "physical_network_name": _j(
+                        tftbase.get_udn_localnet_physical_network()
+                    ),
+                },
+                out_file=out_yaml,
+            )
+            logger.info(
+                f'Generate Localnet CUDN Yaml "{out_yaml}" (from "{in_template}")'
+            )
+            client.oc(f"apply -f {out_yaml}", die_on_error=True, namespace=None)
 
         self._configure_namespace(cfg_descr, namespace=udn_ns)
         self._udn_setup_done = True
@@ -234,6 +262,11 @@ class TrafficFlowTests:
         tft = cfg_descr.get_tft()
         udn_ns = f"{tft.namespace}-udn"
         client = cfg_descr.tc.client_tenant
+        client.oc(
+            "delete clusteruserdefinednetwork -l tft-tests",
+            namespace=None,
+            may_fail=True,
+        )
         if client.oc_get(f"namespace/{udn_ns}", may_fail=True) is None:
             return
         logger.info(
@@ -304,6 +337,11 @@ class TrafficFlowTests:
             return
         udn_ns = self._udn_ns
         client = cfg_descr.tc.client_tenant
+        client.oc(
+            "delete clusteruserdefinednetwork -l tft-tests",
+            namespace=None,
+            may_fail=True,
+        )
         client.oc(f"delete userdefinednetwork -l tft-tests -n {udn_ns}", may_fail=True)
         if self._udn_ns_created:
             logger.info(f"Deleting UDN namespace {udn_ns}")


### PR DESCRIPTION
Add ClusterIP and NodePort service tests for secondary UDN, and pod-to-pod, ClusterIP, and NodePort tests for localnet UDN via ClusterUserDefinedNetwork.