### PR TITLE
Suppress cleanup errors to debug log level

### DIFF
--- a/task.py
+++ b/task.py
@@ -627,7 +627,7 @@ class Task(ABC):
                             pod_ip = network["ips"][0]
                             break
         except Exception as e:
-            logger.error(f"Error retrieving pod IP for {self.pod_name}: {e}")
+            logger.debug(f"Error retrieving pod IP for {self.pod_name}: {e}")
         if not isinstance(pod_ip, str):
             raise RuntimeError(f"Failure to get pod IP for {self.pod_name}")
         return pod_ip

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -145,6 +145,7 @@ class TrafficFlowTests:
         client.oc(
             "delete multi-networkpolicies -l tft-tests",
             namespace=namespace,
+            may_fail=True,
             check_success=client.check_success_delete_ignore_noexist(
                 "multi-networkpolicies"
             ),
@@ -152,12 +153,14 @@ class TrafficFlowTests:
         client.oc(
             "delete networkpolicies -l tft-tests",
             namespace=namespace,
+            may_fail=True,
             check_success=client.check_success_delete_ignore_noexist("networkpolicies"),
         )
 
         client.oc(
             "delete adminnetworkpolicies -l tft-tests",
             namespace=None,
+            may_fail=True,
             check_success=client.check_success_delete_ignore_noexist(
                 "adminnetworkpolicies"
             ),
@@ -203,10 +206,11 @@ class TrafficFlowTests:
             )
             host.local.run(
                 f"podman rm --force {task.EXTERNAL_PERF_SERVER}",
-                log_level_fail=logging.WARN,
+                log_level_fail=logging.DEBUG,
                 check_success=lambda r: (
                     r.success
                     or (r.returncode == 1 and "no container with name or ID" in r.err)
+                    or r.returncode == 127
                 ),
             )
         else:


### PR DESCRIPTION
Update error messages (podman, adminnetworkpolicies, missing secondary network annotation, etc.) from ERROR/WARN to DEBUG so they don't clutter normal test output.

Update podman cleanup to succeed if podman does not exist locally, meaning that it is not applicable.