### PR TITLE
Remove port from pod names and use pod name for service selectors

### DIFF
--- a/manifests/host-pod.yaml.j2
+++ b/manifests/host-pod.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: {{ pod_name }}
   labels:
     tft-tests: {{ label_tft_tests }}
-    tft-port: "{{ port }}"
+    tft-pod-name: {{ pod_name }}
     tft-network: primary
 spec:
   hostNetwork: true

--- a/manifests/pod-secondary-network.yaml.j2
+++ b/manifests/pod-secondary-network.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: {{ pod_name }}
   labels:
     tft-tests: {{ label_tft_tests }}
-    tft-port: "{{ port }}"
+    tft-pod-name: {{ pod_name }}
     tft-network: secondary
   annotations:
     k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }}

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: {{ pod_name }}
   labels:
     tft-tests: {{ label_tft_tests }}
-    tft-port: "{{ port }}"
+    tft-pod-name: {{ pod_name }}
     tft-network: primary
 spec:
   nodeSelector:

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -8,7 +8,7 @@ metadata:
     k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }} {% endif %}
   labels:
     tft-tests: {{ label_tft_tests }}
-    tft-port: "{{ port }}"
+    tft-pod-name: {{ pod_name }}
     tft-network: primary
 spec:
   nodeSelector:

--- a/manifests/svc-cluster-ip.yaml.j2
+++ b/manifests/svc-cluster-ip.yaml.j2
@@ -15,5 +15,4 @@ spec:
       protocol: UDP
       port: {{ port }}
   selector:
-    tft-port: "{{ port }}"
-    tft-network: {{ network_type }}
+    tft-pod-name: {{ pod_name }}

--- a/manifests/svc-loadbalancer.yaml.j2
+++ b/manifests/svc-loadbalancer.yaml.j2
@@ -16,5 +16,4 @@ spec:
       protocol: UDP
       port: {{ port }}
   selector:
-    tft-port: "{{ port }}"
-    tft-network: {{ network_type }}
+    tft-pod-name: {{ pod_name }}

--- a/manifests/svc-node-port.yaml.j2
+++ b/manifests/svc-node-port.yaml.j2
@@ -15,5 +15,4 @@ spec:
       protocol: UDP
       port: {{ port }}
   selector:
-    tft-port: "{{ port }}"
-    tft-network: {{ network_type }}
+    tft-pod-name: {{ pod_name }}

--- a/task.py
+++ b/task.py
@@ -1105,7 +1105,7 @@ class ServerTask(Task, ABC):
             ConnectionMode.MNP_PRIMARY_DENY,
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
-            pod_name = f"normal-pod-secondary-network-server-{port}"
+            pod_name = f"normal-pod-secondary-server-{port}"
         elif pod_type == PodType.SRIOV:
             in_file_template = "sriov-pod.yaml.j2"
             pod_name = f"sriov-pod-server-{port}"
@@ -1145,15 +1145,19 @@ class ServerTask(Task, ABC):
         )
         return f"{prefix}-{self.port}"
 
+    def ensure_services(self) -> None:
+        if self.in_file_template != "":
+            if self.get_cluster_ip() is None:
+                self.create_cluster_ip_service()
+            if self.get_nodeport_ip() is None:
+                self.create_node_port_service()
+
     def initialize(self) -> None:
         super().initialize()
 
         if self.in_file_template != "":
             self.render_pod_file("Server Pod Yaml")
-            if self.get_cluster_ip() is None:
-                self.create_cluster_ip_service()
-            if self.get_nodeport_ip() is None:
-                self.create_node_port_service()
+        self.ensure_services()
 
     def _get_template_args_args(self) -> list[str]:
         if not self.exec_persistent:
@@ -1400,16 +1404,16 @@ class ClientTask(Task, ABC):
             ConnectionMode.MNP_PRIMARY_DENY,
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
-            pod_name = f"normal-pod-secondary-network-{node_location}-client-{port}"
+            pod_name = f"normal-pod-secondary-{node_location}-client"
         elif pod_type == PodType.SRIOV:
             in_file_template = "sriov-pod.yaml.j2"
-            pod_name = f"sriov-pod-{node_location}-client-{port}"
+            pod_name = f"sriov-pod-{node_location}-client"
         elif pod_type == PodType.NORMAL:
             in_file_template = "pod.yaml.j2"
-            pod_name = f"normal-pod-{node_location}-client-{port}"
+            pod_name = f"normal-pod-{node_location}-client"
         elif pod_type == PodType.HOSTBACKED:
             in_file_template = "host-pod.yaml.j2"
-            pod_name = f"host-pod-{node_location}-client-{port}"
+            pod_name = f"host-pod-{node_location}-client"
         else:
             raise ValueError("Invalid pod_type {pod_type}")
 

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -353,6 +353,8 @@ class TrafficFlowTests:
                         seen_server_pods.add(s.pod_name)
                         s.initialize()
                         s.start_setup(provisioning=True)
+                    else:
+                        s.ensure_services()
 
                     if c.pod_name not in seen_client_pods:
                         seen_client_pods.add(c.pod_name)


### PR DESCRIPTION
Pod names no longer include the port suffix, allowing pods to be reused across test types in pre_provision mode. Service selectors now match on tft-pod-name instead of tft-port and tft-network. Reduces the number of overall pods deployed if running with different connection types concurrently and the number of pods will stay consistent as connection types increase.

Created ensure_services() from initialize() so pre-provisioned server pods create services, which are still unique to the test type since they operate on port-protocol binding.

