### PR TITLE
Share one pod for primary and secondary tests in pre_provision mode

### DIFF
--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -481,11 +481,7 @@ class TaskValidateOffload(PluginTask):
                 logger.info("There is no VF on an external server")
                 msg = "External Iperf Server"
             else:
-                ifname = (
-                    "net1"
-                    if self._perf_instance._network_type == "secondary"
-                    else "eth0"
-                )
+                ifname = "net1" if self._perf_instance.uses_secondary_ip else "eth0"
                 # Get VF representor - use DPU mode if configured
                 if self._is_dpu_mode:
                     logger.info("DPU mode: querying VF representor from DPU cluster")

--- a/task.py
+++ b/task.py
@@ -45,12 +45,6 @@ logger = common.ExtendedLogger("tft." + __name__)
 
 EXTERNAL_PERF_SERVER = "external-perf-server"
 
-_SECONDARY_MODES = (
-    ConnectionMode.MULTI_HOME,
-    ConnectionMode.MNP_2ND_DENY,
-    ConnectionMode.MNP_2ND_ALLOW,
-)
-
 
 NP_ACTION_ALLOW = "Allow"
 NP_ACTION_DENY = "Deny"
@@ -485,13 +479,17 @@ class Task(ABC):
 
     @property
     def _network_type(self) -> str:
-        if (
-            self.ts.connection_mode in _SECONDARY_MODES
-            or self.ts.test_case_id.is_udn_secondary
-            or self.ts.test_case_id.is_udn_localnet
-        ):
+        if self.pod_type == PodType.SECONDARY:
             return "secondary"
         return "primary"
+
+    @property
+    def uses_secondary_ip(self) -> bool:
+        # MNP_PRIMARY_DENY is a SECONDARY pod, but its traffic still flows on the primary IP
+        return (
+            self._network_type == "secondary"
+            and self.ts.connection_mode != ConnectionMode.MNP_PRIMARY_DENY
+        )
 
     def render_pod_file(self, log_info: str) -> None:
         self.render_file(
@@ -621,10 +619,7 @@ class Task(ABC):
                             f"falling back to status.podIP"
                         )
                         pod_ip = y["status"]["podIP"]
-                elif (
-                    self._get_node_secondary_network_nad()
-                    or self.ts.connection.secondary_network_nad
-                ):
+                elif self.uses_secondary_ip:
                     network_status_str = y["metadata"]["annotations"][
                         "k8s.v1.cni.cncf.io/network-status"
                     ]
@@ -1115,9 +1110,9 @@ class ServerTask(Task, ABC):
         elif connection_mode == ConnectionMode.EXTERNAL_IP:
             in_file_template = ""
             pod_name = EXTERNAL_PERF_SERVER
-        elif (
-            self._network_type == "secondary"
-            or connection_mode == ConnectionMode.MNP_PRIMARY_DENY
+        elif pod_type == PodType.SECONDARY or (
+            ts.cfg_descr.get_tft().pre_provision
+            and ts.cfg_descr.get_tft().uses_secondary_network_pod
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = f"normal-pod-secondary-server-{port}"
@@ -1422,9 +1417,9 @@ class ClientTask(Task, ABC):
         port = server.port
         connection_mode = ts.connection_mode
 
-        if (
-            self._network_type == "secondary"
-            or connection_mode == ConnectionMode.MNP_PRIMARY_DENY
+        if pod_type == PodType.SECONDARY or (
+            ts.cfg_descr.get_tft().pre_provision
+            and ts.cfg_descr.get_tft().uses_secondary_network_pod
         ):
             in_file_template = "pod-secondary-network.yaml.j2"
             pod_name = f"normal-pod-secondary-{node_location}-client"

--- a/testConfig.py
+++ b/testConfig.py
@@ -657,6 +657,10 @@ class ConfTest(StructParseBaseNamed):
             cwd=self.config.test_config.cwddir,
         )
 
+    @property
+    def uses_secondary_network_pod(self) -> bool:
+        return any(tc.info.uses_secondary_network_pod for tc in self.test_cases)
+
     def get_output_file(self) -> pathlib.Path:
         output_base = self.config.test_config.output_base
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -368,6 +368,7 @@ class PodType(Enum):
     NORMAL = 1
     SRIOV = 2
     HOSTBACKED = 3
+    SECONDARY = 4
 
 
 class TestCaseType(Enum):
@@ -471,6 +472,13 @@ class ConnectionMode(Enum):
     NP_ALLOW = 13
     LOAD_BALANCER = 14
 
+
+_SECONDARY_MODES = (
+    ConnectionMode.MULTI_HOME,
+    ConnectionMode.MNP_2ND_DENY,
+    ConnectionMode.MNP_2ND_ALLOW,
+    ConnectionMode.MNP_PRIMARY_DENY,
+)
 
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
@@ -908,9 +916,19 @@ class TestCaseTypInfo:
             return "same-node"
         return "diff-node"
 
+    @property
+    def uses_secondary_network_pod(self) -> bool:
+        return (
+            self.connection_mode in _SECONDARY_MODES
+            or self.test_case_type.is_udn_secondary
+            or self.test_case_type.is_udn_localnet
+        )
+
     def get_server_pod_type(self, pod_type: PodType) -> PodType:
         if self.is_server_hostbacked:
             return PodType.HOSTBACKED
+        if self.uses_secondary_network_pod:
+            return PodType.SECONDARY
         if pod_type == PodType.SRIOV:
             return PodType.SRIOV
         return PodType.NORMAL
@@ -918,6 +936,8 @@ class TestCaseTypInfo:
     def get_client_pod_type(self, pod_type: PodType) -> PodType:
         if self.is_client_hostbacked:
             return PodType.HOSTBACKED
+        if self.uses_secondary_network_pod:
+            return PodType.SECONDARY
         if pod_type == PodType.SRIOV:
             return PodType.SRIOV
         return PodType.NORMAL


### PR DESCRIPTION
When pre_provision is enabled and a run contains any secondary-network test case, use the secondary-network pod for both the server and the client side for both NORMAL pod types and secondary tests. This reduces the number of resources deployed.

This shared pod has both the primary CNI interface and the secondary NAD interface. HOSTBACKED, SRIOV, and EXTERNAL_IP pod types are unaffected.