### PR TITLE
Optionally disable time/thread preamble in INFO level logging

### DIFF
--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -18,6 +18,7 @@ jobs:
             dpu_sim_config: config-kind.yaml
           - scenario: diverse-subset
             dpu_sim_config: config-kind.yaml
+            tft_log_preamble: "false"
           - scenario: resource-limits
             dpu_sim_config: config-kind.yaml
           - scenario: dpu-offload
@@ -109,6 +110,7 @@ jobs:
         working-directory: dpu-simulator
         env:
           TFT_KUBECONFIG: ${{ github.workspace }}/dpu-simulator/kubeconfig/dpu-sim-host.kubeconfig
+          TFT_LOG_PREAMBLE: ${{ matrix.tft_log_preamble }}
         run: |
           ./bin/dpu-sim tft run \
             --config ${{ matrix.dpu_sim_config }} \

--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ tft:
 - `TFT_EXTERNAL_SERVER_STRING` expected substring in the HTTP response body when
      `TFT_EXTERNAL_URL` is set. Defaults to `"The document has moved"` (the body of an HTTP 301
      redirect).
+- `TFT_LOG_PREAMBLE` enable or disable the timestamp and thread preamble that ktoolbox
+     prepends to every log record. Defaults to `true`, which keeps the existing ktoolbox format. 
+     Set to `false` to strip the preamble and log only `LEVEL: message`.
 
 ## File Transfer via magic-wormhole
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -157,7 +157,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_logger(args.verbose, "tft", "ktoolbox")
+    tftbase.configure_logging(args.verbose, "tft", "ktoolbox")
 
     if args.config and not Path(args.config).exists():
         logger.error(f"No config file found at {args.config}, exiting")

--- a/generate_eval_config.py
+++ b/generate_eval_config.py
@@ -209,7 +209,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_logger(args.verbose, "tft", "ktoolbox")
+    tftbase.configure_logging(args.verbose, "tft", "ktoolbox")
 
     if args.tighten_only and not args.config:
         logger.error(

--- a/print_results.py
+++ b/print_results.py
@@ -151,7 +151,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_logger(args.verbose, "tft", "ktoolbox")
+    tftbase.configure_logging(args.verbose, "tft", "ktoolbox")
 
     return args
 

--- a/tft.py
+++ b/tft.py
@@ -90,7 +90,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_logger(args.verbosity, "tft", "ktoolbox")
+    tftbase.configure_logging(args.verbosity, "tft", "ktoolbox")
 
     if not Path(args.config).exists():
         raise ValueError("Must provide a valid config.yaml file (see config.yaml)")

--- a/tftbase.py
+++ b/tftbase.py
@@ -1,6 +1,7 @@
 import dataclasses
 import functools
 import json
+import logging
 import math
 import os
 import re
@@ -12,6 +13,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 from typing import Optional
+from typing import Union
 
 from ktoolbox import common
 from ktoolbox import host
@@ -36,11 +38,49 @@ ENV_TFT_MANIFESTS_YAMLS = "TFT_MANIFESTS_YAMLS"
 ENV_TFT_EXTERNAL_URL = "TFT_EXTERNAL_URL"
 ENV_TFT_EXTERNAL_SERVER_STRING = "TFT_EXTERNAL_SERVER_STRING"
 
+ENV_TFT_LOG_PREAMBLE = "TFT_LOG_PREAMBLE"
+
 
 def get_environ(name: str) -> Optional[str]:
     # Some environment variables are honored as configuration.
     # Which ones? Run `git grep -w get_environ`!
     return common.getenv_config(name)
+
+
+def _get_log_preamble() -> bool:
+    return common.str_to_bool(
+        get_environ(ENV_TFT_LOG_PREAMBLE), on_default=True, on_error=True
+    )
+
+
+def configure_logging(
+    level: Optional[Union[int, bool, str]],
+    *loggers: Union[str, logging.Logger],
+) -> None:
+    # Wraps `common.log_config_logger` so the timestamp/thread preamble that
+    # ktoolbox always prepends (e.g. "2026-01-01 07:39:38.957 INFO    [th:123]:")
+    # can be stripped via the TFT_LOG_PREAMBLE env var.
+    # Default (true) preserves ktoolbox's built-in formatter.
+    common.log_config_logger(level, *loggers)
+
+    if _get_log_preamble():
+        return
+
+    formatter = logging.Formatter("%(levelname)-7s: %(message)s")
+
+    seen: set[int] = set()
+    for lg in loggers:
+        real_logger = common.ExtendedLogger.unwrap(lg)
+        cur: Optional[logging.Logger] = real_logger
+        while cur is not None:
+            for h in cur.handlers:
+                if id(h) in seen:
+                    continue
+                seen.add(id(h))
+                h.setFormatter(formatter)
+            if not cur.propagate:
+                break
+            cur = cur.parent
 
 
 def _is_ib_test_type(test_type: "TestType") -> bool:


### PR DESCRIPTION
New variable TFT_LOG_PREAMBLE can be set to true/false to enable/disable adding time and thread info to every INFO log. Defaults to true, preserving ktoolbox's existing format; when false, records are rendered as "LEVEL: message".

Implemented as a wrapper around the currently-used logging function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `TFT_LOG_PREAMBLE` environment variable to control log formatting. Set to `false` to disable timestamp and thread information in log output; defaults to `true` to include full preamble information with each log entry. This allows users to customize log verbosity based on their needs.

* **Documentation**
  * Updated README with the new `TFT_LOG_PREAMBLE` environment variable and configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/kubernetes-traffic-flow-tests/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->