### PR TITLE
Add UDN_PRIMARY external, NP, and load balancer test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,26 +129,31 @@ kubeconfig_infra: (30)
     | 40 | UDN_PRIMARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
     | 41 | UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
     | 42 | UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
-    | 43 | UDN_SECONDARY_POD_TO_POD_SAME_NODE |
-    | 44 | UDN_SECONDARY_POD_TO_POD_DIFF_NODE |
-    | 45 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
-    | 46 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
-    | 47 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
-    | 48 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
-    | 49 | UDN_LOCALNET_POD_TO_POD_SAME_NODE |
-    | 50 | UDN_LOCALNET_POD_TO_POD_DIFF_NODE |
-    | 51 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
-    | 52 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
-    | 53 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
-    | 54 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
-    | 55 | POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
-    | 56 | POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
-    | 57 | POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
-    | 58 | POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
-    | 59 | HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
-    | 60 | HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
-    | 61 | HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
-    | 62 | HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
+    | 43 | UDN_PRIMARY_POD_TO_EXTERNAL |
+    | 44 | UDN_PRIMARY_POD_TO_POD_NP_DENY |
+    | 45 | UDN_PRIMARY_POD_TO_POD_NP_ALLOW |
+    | 46 | UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
+    | 47 | UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
+    | 48 | UDN_SECONDARY_POD_TO_POD_SAME_NODE |
+    | 49 | UDN_SECONDARY_POD_TO_POD_DIFF_NODE |
+    | 50 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
+    | 51 | UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
+    | 52 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
+    | 53 | UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
+    | 54 | UDN_LOCALNET_POD_TO_POD_SAME_NODE |
+    | 55 | UDN_LOCALNET_POD_TO_POD_DIFF_NODE |
+    | 56 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE |
+    | 57 | UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE |
+    | 58 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE |
+    | 59 | UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE |
+    | 60 | POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
+    | 61 | POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
+    | 62 | POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
+    | 63 | POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
+    | 64 | HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE |
+    | 65 | HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE |
+    | 66 | HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE |
+    | 67 | HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE |
 4. "duration" - The duration that each individual test will run for.
 5. "pre_provision" - (Optional) Whether to pre-provision all pods and services once before the test run begins, rather than creating and tearing them down per test case. Defaults to false. Takes in "true/false".
 6. "name" - This is the connection name. Any string value to identify the connection.
@@ -194,11 +199,15 @@ kubeconfig_infra: (30)
 
 See the [OVN-Kubernetes UDN documentation](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/user-defined-networks.md) for details on User Defined Networks.
 
-Test cases 37-54 run traffic over OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically.
+Test cases 37-59 run traffic over OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically. NetworkPolicies and LoadBalancer services for UDN tests are also created in (and torn down from) the `{namespace}-udn` namespace.
 
-- **37-42** (Primary UDN): Layer3 network replacing the pod's default network. Supports pod-to-pod, ClusterIP, and NodePort.
-- **43-48** (Secondary UDN): Layer2 network attached as a 2nd interface. Supports pod-to-pod, ClusterIP, and NodePort.
-- **49-54** (Localnet UDN): Localnet topology secondary network via ClusterUserDefinedNetwork, providing direct L2 access. Supports pod-to-pod, ClusterIP, and NodePort.
+- **37-47** (Primary UDN): Layer3 network replacing the pod's default network.
+  - **37-42**: pod-to-pod, ClusterIP, and NodePort.
+  - **43**: pod-to-external (egress out of the UDN to the public internet).
+  - **44-45**: NetworkPolicy enforcement on the primary UDN (deny / allow).
+  - **46-47**: pod-to-LoadBalancer-to-pod (same / different node).
+- **48-53** (Secondary UDN): Layer2 network attached as a 2nd interface. Supports pod-to-pod, ClusterIP, and NodePort.
+- **54-59** (Localnet UDN): Localnet topology secondary network via ClusterUserDefinedNetwork, providing direct L2 access. Supports pod-to-pod, ClusterIP, and NodePort.
 
 CIDRs default to `15.1.0.0/16` (primary), `15.2.0.0/16` (secondary), and `15.3.0.0/24` (localnet), overridable via `TFT_UDN_PRIMARY_CIDR`, `TFT_UDN_SECONDARY_CIDR`, and `TFT_UDN_LOCALNET_CIDR`. The localnet physical network name defaults to `physnet`, overridable via `TFT_UDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn-primary.yaml.j2`, `manifests/udn-secondary.yaml.j2`, and `manifests/udn-localnet.yaml.j2`.
 

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -209,6 +209,31 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 18
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: UDN_SECONDARY_POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -516,6 +541,31 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/task.py
+++ b/task.py
@@ -342,7 +342,7 @@ class Task(ABC):
     def get_namespace(self) -> str:
         ns = self.ts.cfg_descr.get_tft().namespace
         if self.ts.test_case_id.is_udn:
-            return f"{ns}-udn"
+            return tftbase.get_udn_namespace(ns)
         return ns
 
     def get_duration(self) -> int:

--- a/tests/eval-config-2.yaml
+++ b/tests/eval-config-2.yaml
@@ -309,6 +309,31 @@ IPERF_TCP:
   Reverse:
     threshold: 10
   id: 62
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 63
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 64
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 65
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 66
+- Normal:
+    threshold: 18
+  Reverse:
+    threshold: 10
+  id: 67
 IPERF_UDP:
 - Normal:
     threshold: 5
@@ -620,3 +645,28 @@ IPERF_UDP:
   Reverse:
     threshold: 5
   id: 62
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 63
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 64
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 65
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 66
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 67

--- a/tests/generate-eval-config-output0.yaml
+++ b/tests/generate-eval-config-output0.yaml
@@ -209,6 +209,31 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 18
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: UDN_SECONDARY_POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -516,6 +541,31 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/generate-eval-config-output2.yaml
+++ b/tests/generate-eval-config-output2.yaml
@@ -246,6 +246,31 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 18
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: UDN_SECONDARY_POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -559,6 +584,31 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/generate-eval-config-output3.yaml
+++ b/tests/generate-eval-config-output3.yaml
@@ -230,6 +230,31 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 18
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
   - id: UDN_SECONDARY_POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
@@ -537,6 +562,31 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_POD_NP_DENY
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_POD_NP_ALLOW
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -129,7 +129,7 @@ def test_test_case_typ_infos() -> None:
         assert ti.test_case_type is typ
         assert typ.info is ti
 
-    assert list(TestCaseType)[-1].value == 62
+    assert list(TestCaseType)[-1].value == 67
     list_numeric = list(range(1, list(TestCaseType)[-1].value + 1))
     assert list_numeric == [typ.value for typ in tftbase.TestCaseType]
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -212,6 +212,10 @@ def get_udn_localnet_cidr() -> str:
     return s
 
 
+def get_udn_namespace(base_namespace: str) -> str:
+    return f"{base_namespace}-udn"
+
+
 @functools.cache
 def get_udn_localnet_physical_network() -> str:
     s = get_environ(ENV_TFT_UDN_LOCALNET_PHYSICAL_NETWORK) or "physnet"
@@ -413,26 +417,31 @@ class TestCaseType(Enum):
     UDN_PRIMARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 40
     UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 41
     UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 42
-    UDN_SECONDARY_POD_TO_POD_SAME_NODE = 43
-    UDN_SECONDARY_POD_TO_POD_DIFF_NODE = 44
-    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 45
-    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 46
-    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 47
-    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 48
-    UDN_LOCALNET_POD_TO_POD_SAME_NODE = 49
-    UDN_LOCALNET_POD_TO_POD_DIFF_NODE = 50
-    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 51
-    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 52
-    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 53
-    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 54
-    POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 55
-    POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 56
-    POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 57
-    POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 58
-    HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 59
-    HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 60
-    HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 61
-    HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 62
+    UDN_PRIMARY_POD_TO_EXTERNAL = 43
+    UDN_PRIMARY_POD_TO_POD_NP_DENY = 44
+    UDN_PRIMARY_POD_TO_POD_NP_ALLOW = 45
+    UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 46
+    UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 47
+    UDN_SECONDARY_POD_TO_POD_SAME_NODE = 48
+    UDN_SECONDARY_POD_TO_POD_DIFF_NODE = 49
+    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 50
+    UDN_SECONDARY_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 51
+    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 52
+    UDN_SECONDARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 53
+    UDN_LOCALNET_POD_TO_POD_SAME_NODE = 54
+    UDN_LOCALNET_POD_TO_POD_DIFF_NODE = 55
+    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_SAME_NODE = 56
+    UDN_LOCALNET_POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE = 57
+    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_SAME_NODE = 58
+    UDN_LOCALNET_POD_TO_NODE_PORT_TO_POD_DIFF_NODE = 59
+    POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 60
+    POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 61
+    POD_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 62
+    POD_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 63
+    HOST_TO_LOAD_BALANCER_TO_POD_SAME_NODE = 64
+    HOST_TO_LOAD_BALANCER_TO_POD_DIFF_NODE = 65
+    HOST_TO_LOAD_BALANCER_TO_HOST_SAME_NODE = 66
+    HOST_TO_LOAD_BALANCER_TO_HOST_DIFF_NODE = 67
 
     @property
     def is_udn(self) -> bool:
@@ -1220,6 +1229,42 @@ _test_case_typ_infos = {
         TestCaseTypInfo(
             test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_NODE_PORT_TO_POD_DIFF_NODE,
             connection_mode=ConnectionMode.NODE_PORT_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_EXTERNAL,
+            connection_mode=ConnectionMode.EXTERNAL_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_POD_NP_DENY,
+            connection_mode=ConnectionMode.NP_DENY,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+            expects_blocked=True,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_POD_NP_ALLOW,
+            connection_mode=ConnectionMode.NP_ALLOW,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_SAME_NODE,
+            connection_mode=ConnectionMode.LOAD_BALANCER,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_LOAD_BALANCER_TO_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.LOAD_BALANCER,
             is_same_node=False,
             is_server_hostbacked=False,
             is_client_hostbacked=False,

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -63,7 +63,7 @@ class TrafficFlowTests:
         if not needs_primary and not needs_secondary and not needs_localnet:
             return
 
-        udn_ns = f"{tft.namespace}-udn"
+        udn_ns = tftbase.get_udn_namespace(tft.namespace)
         client = cfg_descr.tc.client_tenant
 
         logger.info(f"Setting up UDN in namespace {udn_ns}")
@@ -235,26 +235,42 @@ class TrafficFlowTests:
             may_fail=True,
         )
 
-    def _cleanup_multi_network_policies(self, cfg_descr: ConfigDescriptor) -> None:
+    def _cleanup_multi_network_policies(
+        self,
+        cfg_descr: ConfigDescriptor,
+        force_cleanup: bool = False,
+    ) -> None:
         namespace = cfg_descr.get_tft().namespace
         client = cfg_descr.tc.client_tenant
-        logger.info(
-            f"Cleaning multi-networkpolicies and admin-networkpolicies with label tft-tests in namespace {namespace}"
-        )
-        client.oc(
-            "delete multi-networkpolicies -l tft-tests",
-            namespace=namespace,
-            may_fail=True,
-            check_success=client.check_success_delete_ignore_noexist(
-                "multi-networkpolicies"
-            ),
-        )
-        client.oc(
-            "delete networkpolicies -l tft-tests",
-            namespace=namespace,
-            may_fail=True,
-            check_success=client.check_success_delete_ignore_noexist("networkpolicies"),
-        )
+        # Cleanup per-test namespace or all namespaces if force_cleanup is True
+        if force_cleanup:
+            namespaces = [namespace]
+            if self._udn_setup_done:
+                namespaces.append(tftbase.get_udn_namespace(namespace))
+        elif cfg_descr.get_test_case().is_udn:
+            namespaces = [tftbase.get_udn_namespace(namespace)]
+        else:
+            namespaces = [namespace]
+        for ns in namespaces:
+            logger.info(
+                f"Cleaning multi-networkpolicies and networkpolicies with label tft-tests in namespace {ns}"
+            )
+            client.oc(
+                "delete multi-networkpolicies -l tft-tests",
+                namespace=ns,
+                may_fail=True,
+                check_success=client.check_success_delete_ignore_noexist(
+                    "multi-networkpolicies"
+                ),
+            )
+            client.oc(
+                "delete networkpolicies -l tft-tests",
+                namespace=ns,
+                may_fail=True,
+                check_success=client.check_success_delete_ignore_noexist(
+                    "networkpolicies"
+                ),
+            )
 
         client.oc(
             "delete adminnetworkpolicies -l tft-tests",
@@ -267,7 +283,7 @@ class TrafficFlowTests:
 
     def _cleanup_stale_udn(self, cfg_descr: ConfigDescriptor) -> None:
         tft = cfg_descr.get_tft()
-        udn_ns = f"{tft.namespace}-udn"
+        udn_ns = tftbase.get_udn_namespace(tft.namespace)
         client = cfg_descr.tc.client_tenant
         client.oc(
             "delete clusteruserdefinednetwork -l tft-tests",
@@ -298,12 +314,12 @@ class TrafficFlowTests:
             )
             client.oc("delete pods -l tft-tests", namespace=namespace)
             client.oc("delete services -l tft-tests", namespace=namespace)
-            self._cleanup_multi_network_policies(cfg_descr)
+            self._cleanup_multi_network_policies(cfg_descr, force_cleanup=force_cleanup)
             if force_cleanup:
                 self._cleanup_secondary_nad(cfg_descr)
 
             if self._udn_setup_done:
-                udn_ns = f"{namespace}-udn"
+                udn_ns = tftbase.get_udn_namespace(namespace)
                 client.oc("delete pods -l tft-tests", namespace=udn_ns)
                 client.oc("delete services -l tft-tests", namespace=udn_ns)
 
@@ -333,17 +349,22 @@ class TrafficFlowTests:
             ):
                 self._cleanup_multi_network_policies(cfg_descr)
             if connection_mode == ConnectionMode.LOAD_BALANCER:
-                logger.info(f"Cleaning LoadBalancer services in namespace {namespace}")
-                client.oc(
-                    "delete services -l tft-svc-type=loadbalancer",
-                    namespace=namespace,
-                )
+                lb_namespaces = [namespace]
+                if cfg_descr.get_test_case().is_udn and self._udn_setup_done:
+                    lb_namespaces.append(tftbase.get_udn_namespace(namespace))
+                for ns in lb_namespaces:
+                    logger.info(f"Cleaning LoadBalancer services in namespace {ns}")
+                    client.oc(
+                        "delete services -l tft-svc-type=loadbalancer",
+                        namespace=ns,
+                    )
 
     def _cleanup_udn(self, cfg_descr: ConfigDescriptor) -> None:
         if self._udn_ns is None:
             return
         udn_ns = self._udn_ns
         client = cfg_descr.tc.client_tenant
+        logger.info(f"Cleaning up UDN resources in namespace {udn_ns}")
         client.oc(
             "delete clusteruserdefinednetwork -l tft-tests",
             namespace=None,


### PR DESCRIPTION
Extends the UDN_PRIMARY block with new test cases to support NetworkPolicy, LoadBalancer, and External test types.

Cleanup is extended to the UDN namespace so NetworkPolicy and LoadBalancer Service resources created in {ns}-udn are deleted properly. Centralize the UDN namespace convention in a new function and call it whenever udn namespace is required.