### PR TITLE
Run HTTP test curl once and use duration as timeout directly

### DIFF
--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -97,16 +97,18 @@ class HttpClient(task.ClientTask):
             else:
                 _check_success = _check_success_podman
 
-            sleep_time = 0.2
-            end_timestamp = time.monotonic() + self.get_duration() - sleep_time
-
-            while True:
+            if expects_blocked:
+                sleep_time = 0.2
+                end_timestamp = time.monotonic() + self.get_duration() - sleep_time
+                while True:
+                    r = self.run_oc_exec(cmd, may_fail=expects_blocked)
+                    if not _check_success(r):
+                        break
+                    if time.monotonic() >= end_timestamp:
+                        break
+                    time.sleep(sleep_time)
+            else:
                 r = self.run_oc_exec(cmd, may_fail=expects_blocked)
-                if not _check_success(r):
-                    break
-                if time.monotonic() >= end_timestamp:
-                    break
-                time.sleep(sleep_time)
 
             self.ts.event_client_finished.set()
 


### PR DESCRIPTION
Drop the retry loop in HTTP client task that runs for the specified duration. Invoke curl once and the result for it determines the test outcome. Used the exact duration value for the curl timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP test behavior refined: tests that expect blocking now poll until completion or timeout, while non-blocking tests run once—reducing unnecessary retries and improving speed.
  * Result evaluation preserved, so pass/fail reporting and timeout handling remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->