### PR TITLE
Add Kind TFT CI Lanes

### DIFF
--- a/.github/tft-configs/diverse-subset.yaml
+++ b/.github/tft-configs/diverse-subset.yaml
@@ -1,0 +1,31 @@
+# Test pre_provision=false with iperf-tcp across a diverse subset of test cases.
+
+tft:
+  - name: "kind-diverse-subset"
+    namespace: "default"
+    test_cases:
+      - POD_TO_POD_SAME_NODE
+      - POD_TO_POD_DIFF_NODE
+      - POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+      - POD_TO_NODE_PORT_TO_POD_SAME_NODE
+      - HOST_TO_HOST_SAME_NODE
+      - HOST_TO_HOST_DIFF_NODE
+      - HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+      - HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+      - POD_TO_EXTERNAL
+      - POD_TO_POD_ANP_ALLOW
+      - POD_TO_POD_NP_DENY
+    duration: 5
+    pre_provision: false
+    connections:
+      - name: "iperf-tcp"
+        type: "iperf-tcp"
+        instances: 1
+        reverse: false
+        server:
+          - name: "dpu-sim-host-worker"
+            persistent: false
+            sriov: false
+        client:
+          - name: "dpu-sim-host-worker2"
+            sriov: false

--- a/.github/tft-configs/dpu-offload.yaml
+++ b/.github/tft-configs/dpu-offload.yaml
@@ -1,0 +1,23 @@
+# Test sriov=true with iperf-tcp
+
+tft:
+  - name: "kind-dpu-offload"
+    namespace: "default"
+    test_cases: "1-26"
+    duration: 5
+    pre_provision: true
+    connections:
+      - name: "iperf-tcp"
+        type: "iperf-tcp"
+        instances: 1
+        reverse: false
+        server:
+          - name: "dpu-sim-host-worker"
+            persistent: false
+            sriov: true
+            default_network: "default/ovn-primary"
+        client:
+          - name: "dpu-sim-host-worker2"
+            sriov: true
+            default_network: "default/ovn-primary"
+        resource_name: "dpusim.io/vf"

--- a/.github/tft-configs/full-suite.yaml
+++ b/.github/tft-configs/full-suite.yaml
@@ -1,0 +1,31 @@
+# Run test cases 1-26 and 32-36 with iperf-tcp, and http-curl.
+
+tft:
+  - name: "kind-full-suite"
+    namespace: "default"
+    test_cases: "1-26,32-36"
+    duration: 5
+    pre_provision: true
+    connections:
+      - name: "iperf-tcp"
+        type: "iperf-tcp"
+        instances: 1
+        reverse: false
+        server:
+          - name: "dpu-sim-host-worker"
+            persistent: false
+            sriov: false
+        client:
+          - name: "dpu-sim-host-worker2"
+            sriov: false
+      - name: "http-curl"
+        type: "http"
+        instances: 1
+        reverse: false
+        server:
+          - name: "dpu-sim-host-worker"
+            persistent: false
+            sriov: false
+        client:
+          - name: "dpu-sim-host-worker2"
+            sriov: false

--- a/.github/tft-configs/resource-limits.yaml
+++ b/.github/tft-configs/resource-limits.yaml
@@ -1,0 +1,33 @@
+# Validates per-pod CPU/memory requests+limits, a persistent server pod, the
+# reverse direction codepath, and a plugin scoped to a subset of test cases.
+
+tft:
+  - name: "kind-resource-limits"
+    namespace: "default"
+    test_cases: "1-12"
+    duration: 5
+    pre_provision: true
+    connections:
+      - name: "iperf-tcp"
+        type: "iperf-tcp"
+        instances: 1
+        reverse: true
+        cpu_request: "10m"
+        cpu_limit: "500m"
+        mem_request: "50Mi"
+        mem_limit: "200Mi"
+        server:
+          - name: "dpu-sim-host-worker"
+            persistent: true
+            sriov: false
+        client:
+          - name: "dpu-sim-host-worker2"
+            sriov: false
+        plugins:
+          - name: measure_cpu
+            test_cases:
+              - POD_TO_POD_SAME_NODE
+              - POD_TO_POD_DIFF_NODE
+              - POD_TO_HOST_SAME_NODE
+              - POD_TO_HOST_DIFF_NODE
+              - POD_TO_CLUSTER_IP_TO_POD_SAME_NODE

--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -1,0 +1,144 @@
+name: Kind TFT
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  kind-tft:
+    strategy:
+      # Keep every scenario running to completion so we can collect artifacts
+      # from each leg independently when one fails.
+      fail-fast: false
+      matrix:
+        include:
+          - scenario: full-suite
+            dpu_sim_config: config-kind.yaml
+          - scenario: diverse-subset
+            dpu_sim_config: config-kind.yaml
+          - scenario: resource-limits
+            dpu_sim_config: config-kind.yaml
+          - scenario: dpu-offload
+            dpu_sim_config: config-kind-ovnk-offload.yaml
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    # Job-level concurrency so matrix.scenario is in scope; workflow-level
+    # concurrency cannot reference matrix.* expressions.
+    concurrency:
+      group: kind-tft-${{ matrix.scenario }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout ovn-k8s-traffic-flow-tests
+        uses: actions/checkout@v4
+
+      - name: Checkout dpu-simulator
+        uses: actions/checkout@v4
+        with:
+          repository: ovn-kubernetes/dpu-simulator
+          ref: main
+          path: dpu-simulator
+
+      - name: Checkout OVN-Kubernetes (master)
+        uses: actions/checkout@v4
+        with:
+          repository: ovn-org/ovn-kubernetes
+          ref: master
+          path: dpu-simulator/ovn-kubernetes
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dpu-simulator/go.mod
+          cache: true
+
+      - name: Install libvirt development headers
+        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up Python for traffic flow tests
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install kind
+        run: |
+          KIND_VERSION=v0.31.0
+          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
+          chmod +x /tmp/kind-linux-amd64
+          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+      - name: Build dpu-sim
+        working-directory: dpu-simulator
+        run: make build
+
+      - name: Disable containerd image store
+        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+        run: |
+          sudo mkdir -p /etc/docker
+          [ -s "/etc/docker/daemon.json" ] && {
+            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          } || {
+            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          }
+          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Deploy KIND cluster
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim --config ${{ matrix.dpu_sim_config }}
+
+      - name: Verify clusters are ready
+        working-directory: dpu-simulator
+        run: |
+          kubectl wait --for=condition=Ready nodes --all \
+            --kubeconfig kubeconfig/dpu-sim-host.kubeconfig --timeout=25m
+          kubectl wait --for=condition=Ready nodes --all \
+            --kubeconfig kubeconfig/dpu-sim-dpu.kubeconfig --timeout=25m
+
+      - name: TFT Python venv
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim tft venv --config ${{ matrix.dpu_sim_config }} --tft-repo-path "$GITHUB_WORKSPACE"
+
+      - name: Run traffic flow tests
+        working-directory: dpu-simulator
+        env:
+          TFT_KUBECONFIG: ${{ github.workspace }}/dpu-simulator/kubeconfig/dpu-sim-host.kubeconfig
+        run: |
+          ./bin/dpu-sim tft run \
+            --config ${{ matrix.dpu_sim_config }} \
+            --tft-repo-path "$GITHUB_WORKSPACE" \
+            --tft-config "$GITHUB_WORKSPACE/.github/tft-configs/${{ matrix.scenario }}.yaml" \
+            --check
+
+      - name: Export kind logs on failure
+        if: failure()
+        run: |
+          kind export logs /tmp/kind-tft-logs --name dpu-sim-host 2>/dev/null || true
+          kind export logs /tmp/kind-tft-logs --name dpu-sim-dpu 2>/dev/null || true
+
+      - name: Upload kind logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-tft-${{ matrix.scenario }}-kind-logs
+          path: /tmp/kind-tft-logs
+          if-no-files-found: ignore
+
+      - name: Upload TFT results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-tft-${{ matrix.scenario }}-ft-logs
+          path: ft-logs
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim --config ${{ matrix.dpu_sim_config }} --cleanup || true


### PR DESCRIPTION
Add Kind TFT job that builds dpu-simulator, deploys two kind clusters (host + dpu) via `dpu-sim`, and runs tft.py against them through `dpu-sim tft run --check`. The --check flag promotes any tft failure into a CI failure rather than letting it pass silently.

4 different jobs are created that test different configuration parameters for the flow tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multiple test configuration scenarios to support diverse infrastructure testing requirements for different deployment and resource constraint conditions
  * Introduced automated CI/CD workflow that executes infrastructure tests across different scenario configurations with timeout controls, concurrent execution with cancellation support, comprehensive logging, error handling, and artifact collection for improved test visibility and debugging capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/kubernetes-traffic-flow-tests/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->