### PR TITLE
Add service target access subtests

### DIFF
--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -16,12 +16,14 @@ jobs:
           - scenario: full-suite
             dpu_sim_config: ci/config-kind-ovnk-offload.yaml
             tft_config: ""
-            tft_env: ""
+            tft_env: |
+              TFT_ENABLE_TARGET_ACCESS_SUBTESTS=true
           - scenario: diverse-subset
             dpu_sim_config: ci/config-kind.yaml
             tft_config: .github/tft-configs/diverse-subset.yaml
             tft_env: |
               TFT_LOG_PREAMBLE=false
+              TFT_DEFAULT_TARGET_ACCESS_MODE=IP
           - scenario: resource-limits
             dpu_sim_config: ci/config-kind-ovnk-offload.yaml
             tft_config: .github/tft-configs/resource-limits.yaml

--- a/README.md
+++ b/README.md
@@ -423,6 +423,12 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
      defaults to "manifests/yamls".
 - `TFT_KUBECONFIG`, `TFT_KUBECONFIG_INFRA` to overwrite the kubeconfigs from the configuration
      file. See also the "--kubeconfig" and "--kubeconfig-infra" command line options.
+- `TFT_DEFAULT_TARGET_ACCESS_MODE` controls the normal target access mode for service-backed
+     tests. Defaults to `SERVICE_NAME`; set to `IP` to use service IPs instead of service DNS
+     names. Accepted values are `IP` and `SERVICE_NAME`.
+- `TFT_ENABLE_TARGET_ACCESS_SUBTESTS` enables extra target access variants for service-backed
+     tests. Defaults to `false`; when `true`, ClusterIP and LoadBalancer tests run both
+     `IP` and `SERVICE_NAME`, while NodePort tests also include `SERVER_NODE_IP`.
 - `TFT_UDN_PRIMARY_CIDR` CIDR for primary UDN tests. Defaults to `15.1.0.0/16`.
 - `TFT_UDN_SECONDARY_CIDR` CIDR for secondary UDN tests. Defaults to `15.2.0.0/16`.
 - `TFT_UDN_LOCALNET_CIDR` CIDR for localnet UDN tests. Defaults to `15.3.0.0/24`.

--- a/print_results.py
+++ b/print_results.py
@@ -49,6 +49,12 @@ def print_flow_test_output(
         f"Test ID: ({test_case_id.value}) {test_case_id.name}",
         f"Test Type: {test_type.name}",
     ]
+    target_access_mode = test_output.tft_metadata.target_access_mode
+    default_target_access_mode = tftbase.get_default_target_access_mode(
+        test_case_id.info.connection_mode
+    )
+    if target_access_mode != default_target_access_mode:
+        parts.append(f"Target Access: {target_access_mode.name}")
     if test_type != tftbase.TestType.HTTP:
         parts.append(f"Reverse: {common.bool_to_str(test_output.tft_metadata.reverse)}")
         parts.append(f"TX Bitrate: {test_output.bitrate_gbps.tx} Gbps")

--- a/task.py
+++ b/task.py
@@ -38,6 +38,7 @@ from tftbase import ConnectionMode
 from tftbase import PluginOutput
 from tftbase import PodType
 from tftbase import TaskRole
+from tftbase import TargetAccessMode
 from tftbase import TestType
 
 _j = json.dumps
@@ -752,8 +753,14 @@ class Task(ABC):
             die_on_error=True,
         )
 
+    def get_cluster_ip_service_name(self) -> str:
+        return f"tft-clusterip-service-{self._svc_backend_label}"
+
+    def get_cluster_ip_service_dns_name(self) -> str:
+        return f"{self.get_cluster_ip_service_name()}.{self.get_namespace()}.svc"
+
     def get_cluster_ip(self) -> Optional[str]:
-        svc_name = f"tft-clusterip-service-{self._svc_backend_label}"
+        svc_name = self.get_cluster_ip_service_name()
         r = self.run_oc(
             f"get service {svc_name} -o=jsonpath='{{.spec.clusterIP}}'",
             may_fail=True,
@@ -781,13 +788,40 @@ class Task(ABC):
             die_on_error=True,
         )
 
+    def get_nodeport_service_name(self) -> str:
+        return f"tft-nodeport-service-{self._svc_backend_label}"
+
+    def get_nodeport_service_dns_name(self) -> str:
+        return f"{self.get_nodeport_service_name()}.{self.get_namespace()}.svc"
+
     def get_nodeport_ip(self) -> Optional[str]:
-        svc_name = f"tft-nodeport-service-{self._svc_backend_label}"
+        svc_name = self.get_nodeport_service_name()
         r = self.run_oc(
             f"get service {svc_name} -o=jsonpath='{{.spec.clusterIP}}'",
             may_fail=True,
         )
         return r.out if r.success else None
+
+    def get_nodeport_port(self, protocol: str) -> Optional[int]:
+        svc_name = self.get_nodeport_service_name()
+        r = self.run_oc(
+            f"get service {svc_name} -o=jsonpath='{{.spec.ports[?(@.protocol==\"{protocol}\")].nodePort}}'",
+            may_fail=True,
+        )
+        if not r.success or not r.out.strip():
+            return None
+        return int(r.out.strip().split()[0])
+
+    def get_node_internal_ip(self, node_name: Optional[str] = None) -> str:
+        node_name = node_name or self.node_name
+        r = self.run_oc(
+            f"get node {shlex.quote(node_name)} -o=jsonpath='{{.status.addresses[?(@.type==\"InternalIP\")].address}}'",
+            namespace=None,
+            may_fail=True,
+        )
+        if r.success and r.out.strip():
+            return r.out.strip().split()[0]
+        raise RuntimeError(f"InternalIP not found for node {node_name}")
 
     def create_load_balancer_service(self) -> None:
         in_file_template = tftbase.get_manifest("svc-loadbalancer.yaml.j2")
@@ -812,8 +846,14 @@ class Task(ABC):
             die_on_error=True,
         )
 
+    def get_load_balancer_service_name(self) -> str:
+        return f"tft-loadbalancer-service-{self._svc_backend_label}"
+
+    def get_load_balancer_service_dns_name(self) -> str:
+        return f"{self.get_load_balancer_service_name()}.{self.get_namespace()}.svc"
+
     def get_load_balancer_ip(self) -> Optional[str]:
-        svc_name = f"tft-loadbalancer-service-{self._svc_backend_label}"
+        svc_name = self.get_load_balancer_service_name()
         r = self.run_oc(
             f"get service {svc_name} -o=jsonpath='{{.status.loadBalancer.ingress[0].ip}}'",
             may_fail=True,
@@ -832,7 +872,7 @@ class Task(ABC):
             time.sleep(5)
         raise RuntimeError(
             f"LoadBalancer IP not assigned within {timeout}s "
-            f"for service tft-loadbalancer-service-{self._svc_backend_label}"
+            f"for service {self.get_load_balancer_service_name()}"
         )
 
     def _create_multi_network_policy(self, action: str, port: int) -> str:
@@ -1489,6 +1529,7 @@ class ClientTask(Task, ABC):
         self.test_type = ts.connection.test_type
         self.test_case_id = ts.test_case_id
         self.reverse = ts.reverse
+        self.target_access_mode = ts.target_access_mode
         self.in_file_template = in_file_template
         self.pod_name = pod_name
 
@@ -1578,29 +1619,57 @@ class ClientTask(Task, ABC):
             # URL is used directly by testTypeHttp; no IP needed.
             return ""
         if self.connection_mode == ConnectionMode.CLUSTER_IP:
-            ip = self.server.get_cluster_ip()
-            if ip is None:
+            if self.target_access_mode == TargetAccessMode.SERVICE_NAME:
+                cluster_ip_service_name = self.server.get_cluster_ip_service_dns_name()
+                logger.debug(
+                    "get_target_ip() ClusterIP service name to "
+                    f"{cluster_ip_service_name}"
+                )
+                return cluster_ip_service_name
+            cluster_ip = self.server.get_cluster_ip()
+            if cluster_ip is None:
                 raise RuntimeError(
                     f"ClusterIP service not found for server {self.server.pod_name}"
                 )
-            logger.debug(f"get_target_ip() ClusterIP connection to {ip}")
-            return ip
+            logger.debug(f"get_target_ip() ClusterIP connection to {cluster_ip}")
+            return cluster_ip
         elif self.connection_mode == ConnectionMode.NODE_PORT_IP:
-            ip = self.server.get_nodeport_ip()
-            if ip is None:
+            if self.target_access_mode == TargetAccessMode.SERVICE_NAME:
+                nodeport_service_name = self.server.get_nodeport_service_dns_name()
+                logger.debug(
+                    f"get_target_ip() NodePort service name to {nodeport_service_name}"
+                )
+                return nodeport_service_name
+            if self.target_access_mode == TargetAccessMode.SERVER_NODE_IP:
+                nodeport_node_ip = self.server.get_node_internal_ip()
+                logger.debug(f"get_target_ip() NodePort node IP to {nodeport_node_ip}")
+                return nodeport_node_ip
+            nodeport_ip = self.server.get_nodeport_ip()
+            if nodeport_ip is None:
                 raise RuntimeError(
                     f"NodePort service not found for server {self.server.pod_name}"
                 )
-            logger.debug(f"get_target_ip() NodePortIP connection to {ip}")
-            return ip
+            logger.debug(f"get_target_ip() NodePortIP connection to {nodeport_ip}")
+            return nodeport_ip
         elif self.connection_mode == ConnectionMode.EXTERNAL_IP:
             host_ip = self.get_host_ip()
             logger.debug(f"get_target_ip() External connection to host {host_ip}")
             return host_ip
         elif self.connection_mode == ConnectionMode.LOAD_BALANCER:
-            ip = self.server.wait_load_balancer_ip()
-            logger.debug(f"get_target_ip() LoadBalancer connection to {ip}")
-            return ip
+            if self.target_access_mode == TargetAccessMode.SERVICE_NAME:
+                load_balancer_service_name = (
+                    self.server.get_load_balancer_service_dns_name()
+                )
+                logger.debug(
+                    "get_target_ip() LoadBalancer service name to "
+                    f"{load_balancer_service_name}"
+                )
+                return load_balancer_service_name
+            load_balancer_ip = self.server.wait_load_balancer_ip()
+            logger.debug(
+                f"get_target_ip() LoadBalancer connection to {load_balancer_ip}"
+            )
+            return load_balancer_ip
         elif self.connection_mode in (
             ConnectionMode.MULTI_HOME,
             ConnectionMode.MNP_2ND_DENY,
@@ -1622,6 +1691,18 @@ class ClientTask(Task, ABC):
             return 0
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
             return self.server.external_port
+        if (
+            self.connection_mode == ConnectionMode.NODE_PORT_IP
+            and self.target_access_mode == TargetAccessMode.SERVER_NODE_IP
+        ):
+            node_port = self.server.get_nodeport_port(
+                tftbase.get_service_protocol(self.test_type)
+            )
+            if node_port is None:
+                raise RuntimeError(
+                    f"NodePort service port not found for server {self.server.pod_name}"
+                )
+            return node_port
         return self.port
 
     def get_host_ip(self) -> str:

--- a/testSettings.py
+++ b/testSettings.py
@@ -19,6 +19,7 @@ class TestSettings:
     cfg_descr: testConfig.ConfigDescriptor
     instance_index: int
     reverse: bool
+    target_access_mode: tftbase.TargetAccessMode = tftbase.TargetAccessMode.IP
 
     event_server_alive: threading.Event = dataclasses.field(
         init=False, default_factory=threading.Event
@@ -138,7 +139,7 @@ class TestSettings:
         return self.test_case_id.info.connection_mode
 
     def get_test_info(self) -> str:
-        return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.test_case_id.info.node_location}
+        return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.test_case_id.info.node_location}, target-access={self.target_access_mode.name}
         Client Node: {self.node_client.name}
             Tenant={self.client_is_tenant}
             Index={self.client_index}
@@ -151,7 +152,7 @@ class TestSettings:
         direction = ""
         if self.reverse:
             direction = "-REV"
-        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}"
+        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}-{self.target_access_mode.name}"
 
     def get_test_metadata(self) -> TestMetadata:
         return TestMetadata(
@@ -161,6 +162,7 @@ class TestSettings:
             test_case_id=self.test_case_id,
             test_type=self.connection.test_type,
             reverse=self.reverse,
+            target_access_mode=self.target_access_mode,
             server=PodInfo(
                 name=self.node_server.name,
                 pod_type=self.server_pod_type,

--- a/testSettings.py
+++ b/testSettings.py
@@ -152,7 +152,12 @@ class TestSettings:
         direction = ""
         if self.reverse:
             direction = "-REV"
-        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}-{self.target_access_mode.name}"
+        target_access = ""
+        if self.target_access_mode != tftbase.get_default_target_access_mode(
+            self.connection_mode
+        ):
+            target_access = f"-{self.target_access_mode.name}"
+        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}{target_access}"
 
     def get_test_metadata(self) -> TestMetadata:
         return TestMetadata(

--- a/tftbase.py
+++ b/tftbase.py
@@ -41,6 +41,8 @@ ENV_TFT_EXTERNAL_SERVER_STRING = "TFT_EXTERNAL_SERVER_STRING"
 ENV_TFT_HOST_NETWORK_NAMESPACE = "TFT_HOST_NETWORK_NAMESPACE"
 
 ENV_TFT_LOG_PREAMBLE = "TFT_LOG_PREAMBLE"
+ENV_TFT_ENABLE_TARGET_ACCESS_SUBTESTS = "TFT_ENABLE_TARGET_ACCESS_SUBTESTS"
+ENV_TFT_DEFAULT_TARGET_ACCESS_MODE = "TFT_DEFAULT_TARGET_ACCESS_MODE"
 
 
 def get_environ(name: str) -> Optional[str]:
@@ -53,6 +55,33 @@ def _get_log_preamble() -> bool:
     return common.str_to_bool(
         get_environ(ENV_TFT_LOG_PREAMBLE), on_default=True, on_error=True
     )
+
+
+@functools.cache
+def get_tft_enable_target_access_subtests() -> bool:
+    value = common.str_to_bool(
+        get_environ(ENV_TFT_ENABLE_TARGET_ACCESS_SUBTESTS),
+        on_default=False,
+        on_error=False,
+    )
+    logger.info(
+        f"env: {ENV_TFT_ENABLE_TARGET_ACCESS_SUBTESTS}={common.bool_to_str(value)}"
+    )
+    return value
+
+
+@functools.cache
+def get_tft_default_target_access_mode_override() -> Optional["TargetAccessMode"]:
+    value = get_environ(ENV_TFT_DEFAULT_TARGET_ACCESS_MODE)
+    if value is None:
+        return None
+
+    if value in ("IP", "SERVICE_NAME"):
+        mode = TargetAccessMode[value]
+        logger.info(f"env: {ENV_TFT_DEFAULT_TARGET_ACCESS_MODE}={mode.name}")
+        return mode
+
+    return None
 
 
 def configure_logging(
@@ -538,6 +567,54 @@ class ConnectionMode(Enum):
     NP_NS_SELECTOR_ALLOW = 15
 
 
+class TargetAccessMode(Enum):
+    IP = 1
+    SERVICE_NAME = 2
+    SERVER_NODE_IP = 3
+
+
+_SERVICE_TARGET_ACCESS_CONNECTION_MODES = (
+    ConnectionMode.CLUSTER_IP,
+    ConnectionMode.NODE_PORT_IP,
+    ConnectionMode.LOAD_BALANCER,
+)
+
+
+def get_default_target_access_mode(
+    connection_mode: ConnectionMode,
+) -> TargetAccessMode:
+    override = get_tft_default_target_access_mode_override()
+    if override == TargetAccessMode.IP:
+        return TargetAccessMode.IP
+    if connection_mode in _SERVICE_TARGET_ACCESS_CONNECTION_MODES:
+        return TargetAccessMode.SERVICE_NAME
+    return TargetAccessMode.IP
+
+
+def get_target_access_modes(
+    connection_mode: ConnectionMode,
+) -> tuple[TargetAccessMode, ...]:
+    if not get_tft_enable_target_access_subtests():
+        return (get_default_target_access_mode(connection_mode),)
+    if connection_mode == ConnectionMode.CLUSTER_IP:
+        return (TargetAccessMode.IP, TargetAccessMode.SERVICE_NAME)
+    if connection_mode == ConnectionMode.NODE_PORT_IP:
+        return (
+            TargetAccessMode.IP,
+            TargetAccessMode.SERVICE_NAME,
+            TargetAccessMode.SERVER_NODE_IP,
+        )
+    if connection_mode == ConnectionMode.LOAD_BALANCER:
+        return (TargetAccessMode.IP, TargetAccessMode.SERVICE_NAME)
+    return (TargetAccessMode.IP,)
+
+
+def get_service_protocol(test_type: "TestType") -> str:
+    if test_type == TestType.IPERF_UDP:
+        return "UDP"
+    return "TCP"
+
+
 _SECONDARY_MODES = (
     ConnectionMode.MULTI_HOME,
     ConnectionMode.MNP_2ND_DENY,
@@ -641,6 +718,7 @@ class TestMetadata:
     reverse: bool
     server: PodInfo
     client: PodInfo
+    target_access_mode: TargetAccessMode = TargetAccessMode.IP
     expects_blocked: bool = False
 
 
@@ -816,9 +894,16 @@ class TftResults:
         return f" in {repr(self.filename)}"
 
     def serialize(self) -> dict[str, Any]:
-        return {
-            TftResults.TFT_TESTS: [common.dataclass_to_dict(o) for o in self],
-        }
+        # Keep default IP access compatible with existing result JSON.
+        data = [common.dataclass_to_dict(o) for o in self]
+        for item in data:
+            metadata = item["flow_test"]["tft_metadata"]
+            if metadata.get("target_access_mode") in (
+                None,
+                TargetAccessMode.IP.name,
+            ):
+                metadata.pop("target_access_mode", None)
+        return {TftResults.TFT_TESTS: data}
 
     def serialize_to_file(
         self,

--- a/tftbase.py
+++ b/tftbase.py
@@ -587,6 +587,8 @@ def get_default_target_access_mode(
     if override == TargetAccessMode.IP:
         return TargetAccessMode.IP
     if connection_mode in _SERVICE_TARGET_ACCESS_CONNECTION_MODES:
+        if connection_mode == ConnectionMode.NODE_PORT_IP:
+            return TargetAccessMode.SERVER_NODE_IP
         return TargetAccessMode.SERVICE_NAME
     return TargetAccessMode.IP
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -584,9 +584,9 @@ def get_default_target_access_mode(
     connection_mode: ConnectionMode,
 ) -> TargetAccessMode:
     override = get_tft_default_target_access_mode_override()
-    if override == TargetAccessMode.IP:
-        return TargetAccessMode.IP
     if connection_mode in _SERVICE_TARGET_ACCESS_CONNECTION_MODES:
+        if override is not None:
+            return override
         if connection_mode == ConnectionMode.NODE_PORT_IP:
             return TargetAccessMode.SERVER_NODE_IP
         return TargetAccessMode.SERVICE_NAME

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -427,6 +427,7 @@ class TrafficFlowTests:
         self,
         cfg_descr: ConfigDescriptor,
         instance_index: int,
+        target_access_mode: tftbase.TargetAccessMode,
         reverse: bool = False,
     ) -> TftResult:
         connection = cfg_descr.get_connection()
@@ -439,6 +440,7 @@ class TrafficFlowTests:
             cfg_descr=cfg_descr,
             instance_index=instance_index,
             reverse=reverse,
+            target_access_mode=target_access_mode,
         )
         logger.info(f"Starting test {ts.get_test_info()}")
         s, c = connection.test_type_handler.create_server_client(ts)
@@ -529,21 +531,27 @@ class TrafficFlowTests:
             connection = cfg_descr2.get_connection()
             logger.info(f"Starting {connection.name}")
             logger.info(f"Number Of Simultaneous connections {connection.instances}")
+            target_access_modes = tftbase.get_target_access_modes(
+                cfg_descr2.get_test_case().info.connection_mode
+            )
             for instance_index in range(connection.instances):
-                tft_results.append(
-                    self._run_test_case_instance(
-                        cfg_descr2,
-                        instance_index=instance_index,
-                    )
-                )
-                if connection.test_type_handler.can_run_reverse(connection):
+                for target_access_mode in target_access_modes:
                     tft_results.append(
                         self._run_test_case_instance(
                             cfg_descr2,
                             instance_index=instance_index,
-                            reverse=True,
+                            target_access_mode=target_access_mode,
                         )
                     )
+                    if connection.test_type_handler.can_run_reverse(connection):
+                        tft_results.append(
+                            self._run_test_case_instance(
+                                cfg_descr2,
+                                instance_index=instance_index,
+                                reverse=True,
+                                target_access_mode=target_access_mode,
+                            )
+                        )
                 self._cleanup_previous_testspace(cfg_descr2)
         return tft_results
 


### PR DESCRIPTION
Add a target access mode for service-backed tests so ClusterIP and LoadBalancer can exercise service DNS names, and NodePort can also target the server node IP. Keep the legacy IP path as the default unless TFT_ENABLE_TARGET_ACCESS_SUBTESTS is enabled.

Carry the selected target access mode through test settings and metadata, while omitting the default IP mode from serialized results and summary output to preserve existing result formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable target access modes so tests can run each connection instance across supported modes (service DNS/IP variants, and additional NodePort/LoadBalancer coverage when enabled).
  * Test output now shows a “Target Access” line when the selected mode isn’t the computed default.
* **Tests**
  * Target access mode is carried through test settings and metadata end-to-end.
  * Test execution expands per mode, including reverse where supported.
* **Documentation**
  * Updated environment variable documentation for `TFT_DEFAULT_TARGET_ACCESS_MODE` and `TFT_ENABLE_TARGET_ACCESS_SUBTESTS`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->