### PR TITLE
Support IPv4, IPv6, and dual-stack flow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,31 +53,32 @@ tft:
         instances: (8)
         reverse: "(9)"
         duration: "(10)"
+        ip_family: "(11)"
         server:
-          - name: "(11)"
-            persistent: "(12)"
-            sriov: "(13)"
-            default_network: "(14)"
-            secondary_network_nad: "(15)"
+          - name: "(12)"
+            persistent: "(13)"
+            sriov: "(14)"
+            default_network: "(15)"
+            secondary_network_nad: "(16)"
         client:
-          - name: "(16)"
-            sriov: "(17)"
-            default_network: "(18)"
-            secondary_network_nad: "(19)"
+          - name: "(17)"
+            sriov: "(18)"
+            default_network: "(19)"
+            secondary_network_nad: "(20)"
         plugins:
-          - name: (20)
-            test_cases: (21)
-          - name: (20)
-        secondary_network_nad: "(22)"
-        resource_name: "(23)"
-        cpu_request: "(24)"
-        cpu_limit: "(25)"
-        mem_request: "(26)"
-        mem_limit: "(27)"
-    privileged_pod: (28)
-    capabilities_pod: (29)
-kubeconfig: (30)
-kubeconfig_infra: (30)
+          - name: (21)
+            test_cases: (22)
+          - name: (21)
+        secondary_network_nad: "(23)"
+        resource_name: "(24)"
+        cpu_request: "(25)"
+        cpu_limit: "(26)"
+        mem_request: "(27)"
+        mem_limit: "(28)"
+    privileged_pod: (29)
+    capabilities_pod: (30)
+kubeconfig: (31)
+kubeconfig_infra: (31)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -156,37 +157,38 @@ kubeconfig_infra: (30)
 8. "instances" - The number of instances that would be created. Default is "1"
 9. "reverse" - (Optional) Whether reverse-direction test should run when supported. Defaults to true. Currently, reverse execution is only supported for iperf-tcp. Takes in "true/false".
 10. "duration" - (Optional) Override the test duration for this connection only, in seconds. If omitted, the tft-level duration is used.
-11. "name" - The node name of the server.
-12. "persistent" - Whether to have the server pod persist after the test. Takes in "true/false"
-13. "sriov" - Whether SRIOV should be used for the server pod. Takes in "true/false"
-14. "default_network" - (Optional) The name of the default network that the sriov pod would use.
-14a. "pod_port" - (Optional) The base port for pod-type servers. Defaults to 5201. When multiple connections are configured, each connection should use a unique port to avoid service conflicts.
-14b. "host_port" - (Optional) The base port for host-backed servers. Defaults to 5301. When multiple connections are configured, each connection should use a unique port to avoid service conflicts.
-15. "secondary_network_nad" - (Optional) The secondary network NAD for the server node. Overrides the connection-level `secondary_network_nad` for the server pod. Useful when server and client require different NADs.
-16. "name" - The node name of the client.
-17. "sriov" - Whether SRIOV should be used for the client pod. Takes in "true/false"
-18. "default_network" - (Optional) The name of the default network that the sriov pod would use.
-18a. "args" - (Optional) Extra command-line arguments to pass to the test tool (iperf3, simple-tcp-server-client). Supported for iperf-tcp, iperf-udp, and simple test types. Can be a string or list of strings.
-19. "secondary_network_nad" - (Optional) The secondary network NAD for the client node. Overrides the connection-level `secondary_network_nad` for the client pod. Useful when server and client require different NADs.
-20. "name" - (Optional) list of plugin names
+11. "ip_family" - (Optional) The IP address family to use for this connection. Accepted values: `ipv4` (default), `ipv6`, `dual-stack`. When omitted, the connection uses IPv4, which is the same behavior as before this field existed. On a dual-stack cluster, this lets you choose which address family (or both) to exercise per-connection.
+12. "name" - The node name of the server.
+13. "persistent" - Whether to have the server pod persist after the test. Takes in "true/false"
+14. "sriov" - Whether SRIOV should be used for the server pod. Takes in "true/false"
+15. "default_network" - (Optional) The name of the default network that the sriov pod would use.
+15a. "pod_port" - (Optional) The base port for pod-type servers. Defaults to 5201. When multiple connections are configured, each connection should use a unique port to avoid service conflicts.
+15b. "host_port" - (Optional) The base port for host-backed servers. Defaults to 5301. When multiple connections are configured, each connection should use a unique port to avoid service conflicts.
+16. "secondary_network_nad" - (Optional) The secondary network NAD for the server node. Overrides the connection-level `secondary_network_nad` for the server pod. Useful when server and client require different NADs.
+17. "name" - The node name of the client.
+18. "sriov" - Whether SRIOV should be used for the client pod. Takes in "true/false"
+19. "default_network" - (Optional) The name of the default network that the sriov pod would use.
+19a. "args" - (Optional) Extra command-line arguments to pass to the test tool (iperf3, simple-tcp-server-client). Supported for iperf-tcp, iperf-udp, and simple test types. Can be a string or list of strings.
+20. "secondary_network_nad" - (Optional) The secondary network NAD for the client node. Overrides the connection-level `secondary_network_nad` for the client pod. Useful when server and client require different NADs.
+21. "name" - (Optional) list of plugin names
     | Name             | Description          |
     | ---------------- | -------------------- |
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
-21. "test_cases" - (Optional) Restrict a plugin to run only for the specified test cases. Uses the same format as the top-level `test_cases` field. By default, the plugin runs for every test case.
-22. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-31, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-31 it defaults to "tft-secondary" if not set. Can be overridden per-node using the server/client level `secondary_network_nad` fields. The framework automatically creates and cleans up the NAD when these test cases are selected or when SRIOV nodes reference a secondary NAD. Subnets, MTU, and topology default to `10.193.0.0/16/26`, `1500`, and `layer3`, overridable via `TFT_SECONDARY_NAD_SUBNETS`, `TFT_SECONDARY_NAD_MTU`, and `TFT_SECONDARY_NAD_TOPOLOGY`.
-23. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test tool will try to autopopulate resource_name based on the secondary+network_nad provided.
-24. "cpu_request" - (Optional) CPU request for server and client pods (e.g. "10m", "500m"). No CPU request is set if omitted.
-25. "cpu_limit" - (Optional) CPU limit for server and client pods (e.g. "20m", "1000m"). No CPU limit is set if omitted.
-26. "mem_request" - (Optional) Memory request for server and client pods (e.g. "50Mi", "100Mi"). No memory request is set if omitted.
-27. "mem_limit" - (Optional) Memory limit for server and client pods (e.g. "100Mi", "200Mi"). No memory limit is set if omitted.
-28. "privileged_pod" - (Optional) - Whether to run test pods as privileged. Defaults to false. Can be set at test level or per-node (server/client).
-29. "capabilities_pod" - (Optional) - Linux capabilities for test pods. Format: `{"add": ["NET_ADMIN", "SYS_TIME"]}`. Can be set at test level (applies to all pods) or per-node (server/client) for fine-grained control. Per-node settings take precedence over test-level settings.
-30. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+22. "test_cases" - (Optional) Restrict a plugin to run only for the specified test cases. Uses the same format as the top-level `test_cases` field. By default, the plugin runs for every test case.
+23. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-31, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-31 it defaults to "tft-secondary" if not set. Can be overridden per-node using the server/client level `secondary_network_nad` fields. The framework automatically creates and cleans up the NAD when these test cases are selected or when SRIOV nodes reference a secondary NAD. Subnets, MTU, and topology default to `10.193.0.0/16/26`, `1500`, and `layer3`, overridable via `TFT_SECONDARY_NAD_SUBNETS`, `TFT_SECONDARY_NAD_MTU`, and `TFT_SECONDARY_NAD_TOPOLOGY`.
+24. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test tool will try to autopopulate resource_name based on the secondary+network_nad provided.
+25. "cpu_request" - (Optional) CPU request for server and client pods (e.g. "10m", "500m"). No CPU request is set if omitted.
+26. "cpu_limit" - (Optional) CPU limit for server and client pods (e.g. "20m", "1000m"). No CPU limit is set if omitted.
+27. "mem_request" - (Optional) Memory request for server and client pods (e.g. "50Mi", "100Mi"). No memory request is set if omitted.
+28. "mem_limit" - (Optional) Memory limit for server and client pods (e.g. "100Mi", "200Mi"). No memory limit is set if omitted.
+29. "privileged_pod" - (Optional) - Whether to run test pods as privileged. Defaults to false. Can be set at test level or per-node (server/client).
+30. "capabilities_pod" - (Optional) - Linux capabilities for test pods. Format: `{"add": ["NET_ADMIN", "SYS_TIME"]}`. Can be set at test level (applies to all pods) or per-node (server/client) for fine-grained control. Per-node settings take precedence over test-level settings.
+31. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
-31. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
+32. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
   which host worker node they belong to. For NVIDIA DPUs, use `provisioning.dpu.nvidia.com/host`.
 
 

--- a/manifests/svc-cluster-ip.yaml.j2
+++ b/manifests/svc-cluster-ip.yaml.j2
@@ -7,6 +7,7 @@ metadata:
     tft-tests: {{ label_tft_tests }}
 spec:
   type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: tft-clusterip-service-tcp-{{ port }}
       protocol: TCP

--- a/manifests/svc-loadbalancer.yaml.j2
+++ b/manifests/svc-loadbalancer.yaml.j2
@@ -8,6 +8,7 @@ metadata:
     tft-svc-type: loadbalancer
 spec:
   type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: tft-loadbalancer-service-tcp-{{ port }}
       protocol: TCP

--- a/manifests/svc-node-port.yaml.j2
+++ b/manifests/svc-node-port.yaml.j2
@@ -7,6 +7,7 @@ metadata:
     tft-tests: {{ label_tft_tests }}
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: tft-nodeport-service-tcp-{{ port }}
       protocol: TCP

--- a/print_results.py
+++ b/print_results.py
@@ -49,6 +49,8 @@ def print_flow_test_output(
         f"Test ID: ({test_case_id.value}) {test_case_id.name}",
         f"Test Type: {test_type.name}",
     ]
+    if test_output.tft_metadata.active_ip_family != tftbase.IpFamily.IPV4:
+        parts.append(f"IP Family: {test_output.tft_metadata.active_ip_family.name}")
     if test_type != tftbase.TestType.HTTP:
         parts.append(f"Reverse: {common.bool_to_str(test_output.tft_metadata.reverse)}")
         parts.append(f"TX Bitrate: {test_output.bitrate_gbps.tx} Gbps")

--- a/task.py
+++ b/task.py
@@ -601,12 +601,23 @@ class Task(ABC):
             namespace=self._get_run_oc_namespace(namespace),
         )
 
+    def _pick_pod_ip_for_family(self, y: dict[str, Any]) -> Optional[str]:
+        family = self.ts.active_ip_family
+        pod_ips = [entry["ip"] for entry in y["status"].get("podIPs", [])]
+        ip = family.pick_ip(pod_ips)
+        if ip is not None:
+            return ip
+        fallback = y["status"].get("podIP")
+        if isinstance(fallback, str) and family.matches(fallback):
+            return fallback
+        return None
+
     def get_pod_ip(self) -> str:
         y = self.run_oc_get(f"pod/{self.pod_name}", die_on_error=True)
         pod_ip = None
         try:
             if y:
-                pod_ip = y["status"]["podIP"]
+                pod_ip = self._pick_pod_ip_for_family(y)
                 if self.ts.test_case_id.is_udn_primary:
                     pod_networks_str = y["metadata"]["annotations"].get(
                         "k8s.ovn.org/pod-networks", ""
@@ -616,15 +627,18 @@ class Task(ABC):
                         for net_info in pod_networks.values():
                             if net_info.get("role") == "primary":
                                 ip_with_cidr = net_info["ip_address"]
-                                pod_ip = ip_with_cidr.split("/")[0]
+                                candidate = ip_with_cidr.split("/")[0]
+                                if self.ts.active_ip_family.matches(candidate):
+                                    pod_ip = candidate
                                 break
                     if pod_ip is None:
                         logger.warning(
                             f"Could not find UDN primary IP for pod {self.pod_name} "
+                            f"matching {self.ts.active_ip_family.name} "
                             f"in k8s.ovn.org/pod-networks annotation, "
                             f"falling back to status.podIP"
                         )
-                        pod_ip = y["status"]["podIP"]
+                        pod_ip = self._pick_pod_ip_for_family(y)
                 elif self.uses_secondary_ip:
                     network_status_str = y["metadata"]["annotations"][
                         "k8s.v1.cni.cncf.io/network-status"
@@ -634,7 +648,7 @@ class Task(ABC):
                     nad = self._get_effective_secondary_network_nad()
                     for network in network_status:
                         if network["name"] == nad:
-                            pod_ip = network["ips"][0]
+                            pod_ip = self.ts.active_ip_family.pick_ip(network["ips"])
                             break
         except Exception as e:
             logger.debug(f"Error retrieving pod IP for {self.pod_name}: {e}")
@@ -646,12 +660,13 @@ class Task(ABC):
         y = self.run_oc_get(f"pod/{self.pod_name}", die_on_error=True)
         pod_ip = None
         if y:
-            pod_ip = y["status"]["podIP"]
+            pod_ip = self._pick_pod_ip_for_family(y)
         if not isinstance(pod_ip, str):
             raise RuntimeError(f"Failure to get podIP for {self.pod_name}")
         return pod_ip
 
     def get_secondary_ip(self) -> str:
+        family = self.ts.active_ip_family
         jsonpath = "{.metadata.annotations.k8s\\.ovn\\.org\\/pod-networks}"
         r = self.run_oc(
             f"get pod {self.pod_name} -o jsonpath='{jsonpath}'", die_on_error=True
@@ -668,19 +683,33 @@ class Task(ABC):
             for net_info in y.values():
                 if net_info.get("role") == "secondary":
                     ip_address_with_cidr = typing.cast(str, net_info["ip_address"])
-                    ip_address = ip_address_with_cidr.split("/")[0]
-                    logger.info(f"Secondary IP: {ip_address}")
-                    return ip_address
+                    candidate = ip_address_with_cidr.split("/")[0]
+                    if family.matches(candidate):
+                        logger.info(f"Secondary IP: {candidate}")
+                        return candidate
             raise RuntimeError(
                 f"Could not find UDN secondary IP for pod {self.pod_name} "
+                f"matching {family.name} "
                 f"in k8s.ovn.org/pod-networks annotation"
             )
 
         nad = self._get_effective_secondary_network_nad()
+        ip_addresses = y[nad].get("ip_addresses", [])
+        if ip_addresses:
+            ips = [addr.split("/")[0] for addr in ip_addresses]
+            ip_address = family.pick_ip(ips)
+            if ip_address is not None:
+                logger.info(f"Secondary IP: {ip_address}")
+                return ip_address
         ip_address_with_cidr = typing.cast(str, y[nad]["ip_address"])
-        ip_address = ip_address_with_cidr.split("/")[0] if ip_address_with_cidr else ""
-        logger.info(f"Secondary IP: {ip_address}")
-        return ip_address
+        candidate = ip_address_with_cidr.split("/")[0] if ip_address_with_cidr else ""
+        if candidate and family.matches(candidate):
+            logger.info(f"Secondary IP: {candidate}")
+            return candidate
+        raise RuntimeError(
+            f"Could not find secondary IP for pod {self.pod_name} "
+            f"matching {family.name}"
+        )
 
     def get_nad_cidrs(self, nad: str) -> list[str]:
         # Matches IPv4 and IPv6 CIDRs
@@ -742,13 +771,27 @@ class Task(ABC):
             die_on_error=True,
         )
 
-    def get_cluster_ip(self) -> Optional[str]:
-        svc_name = f"tft-clusterip-service-{self._svc_backend_label}"
+    def _get_service_ip(self, svc_name: str) -> Optional[str]:
+        family = self.ts.active_ip_family
+        r = self.run_oc(
+            f"get service {svc_name} -o=jsonpath='{{.spec.clusterIPs[*]}}'",
+            may_fail=True,
+        )
+        if r.success and r.out:
+            ip = family.pick_ip(r.out.split())
+            if ip is not None:
+                return ip
         r = self.run_oc(
             f"get service {svc_name} -o=jsonpath='{{.spec.clusterIP}}'",
             may_fail=True,
         )
-        return r.out if r.success else None
+        if r.success and r.out and family.matches(r.out):
+            return r.out
+        return None
+
+    def get_cluster_ip(self) -> Optional[str]:
+        svc_name = f"tft-clusterip-service-{self._svc_backend_label}"
+        return self._get_service_ip(svc_name)
 
     def create_node_port_service(self) -> None:
         in_file_template = tftbase.get_manifest("svc-node-port.yaml.j2")
@@ -773,11 +816,7 @@ class Task(ABC):
 
     def get_nodeport_ip(self) -> Optional[str]:
         svc_name = f"tft-nodeport-service-{self._svc_backend_label}"
-        r = self.run_oc(
-            f"get service {svc_name} -o=jsonpath='{{.spec.clusterIP}}'",
-            may_fail=True,
-        )
-        return r.out if r.success else None
+        return self._get_service_ip(svc_name)
 
     def create_load_balancer_service(self) -> None:
         in_file_template = tftbase.get_manifest("svc-loadbalancer.yaml.j2")
@@ -804,11 +843,22 @@ class Task(ABC):
 
     def get_load_balancer_ip(self) -> Optional[str]:
         svc_name = f"tft-loadbalancer-service-{self._svc_backend_label}"
+        family = self.ts.active_ip_family
+        r = self.run_oc(
+            f"get service {svc_name} -o=jsonpath='{{.status.loadBalancer.ingress[*].ip}}'",
+            may_fail=True,
+        )
+        if r.success and r.out:
+            ip = family.pick_ip(r.out.split())
+            if ip is not None:
+                return ip
         r = self.run_oc(
             f"get service {svc_name} -o=jsonpath='{{.status.loadBalancer.ingress[0].ip}}'",
             may_fail=True,
         )
-        return r.out if r.success and r.out else None
+        if r.success and r.out and family.matches(r.out):
+            return r.out
+        return None
 
     def wait_load_balancer_ip(self, timeout: int = 120) -> str:
         deadline = time.monotonic() + timeout
@@ -1324,11 +1374,14 @@ class ServerTask(Task, ABC):
             if tftbase.get_tft_image_pull_policy() == "Always":
                 pull_policy = " --pull=always"
 
-            # Use -p {port} to let podman auto-assign a free host port
             test_image = tftbase.get_tft_test_image_for_type(
                 self.ts.connection.test_type
             )
-            cmd = f"podman run -it --replace --rm -p {self.port} --name={self.pod_name}{pull_policy} {test_image} {th_cmd}"
+            if self.ts.active_ip_family == tftbase.IpFamily.IPV6:
+                port_flag = f"-p [::]:0:{self.port}"
+            else:
+                port_flag = f"-p {self.port}"
+            cmd = f"podman run -it --replace --rm {port_flag} --name={self.pod_name}{pull_policy} {test_image} {th_cmd}"
             cancel_cmd = f"podman rm --force {self.pod_name}"
         else:
             if not skip_pod_setup:
@@ -1512,8 +1565,11 @@ class ClientTask(Task, ABC):
 
     def get_host_ip(self) -> str:
         """Get the host's IP address for EXTERNAL_IP mode."""
-        # Get the IP from default route using JSON output
-        r = self.lh.run("ip -j route get 1")
+        if self.ts.active_ip_family == tftbase.IpFamily.IPV6:
+            cmd = "ip -6 -j route get 2001:4860:4860::8888"
+        else:
+            cmd = "ip -j route get 1"
+        r = self.lh.run(cmd)
         if r.success and r.out.strip():
             try:
                 routes = json.loads(r.out.strip())
@@ -1523,7 +1579,10 @@ class ClientTask(Task, ABC):
                     return ip
             except (json.JSONDecodeError, KeyError, IndexError):
                 pass
-        raise RuntimeError("Failed to get host IP address from default route")
+        raise RuntimeError(
+            f"Failed to get host IP address from default route "
+            f"for {self.ts.active_ip_family.name}"
+        )
 
     def get_podman_ip(self, pod_name: str) -> str:
         cmd = "podman inspect --format '{{.NetworkSettings.IPAddress}}' " + pod_name

--- a/testConfig.py
+++ b/testConfig.py
@@ -28,6 +28,7 @@ from ktoolbox.k8sClient import K8sClient
 from pluginbase import Plugin
 from testType import TestTypeHandler
 from tftbase import ClusterMode
+from tftbase import IpFamily
 from tftbase import PodType
 from tftbase import TestCaseType
 from tftbase import TestType
@@ -358,6 +359,7 @@ class ConfConnection(StructParseBaseNamed):
     secondary_network_nad: Optional[str]
     resource_name: Optional[str]
     duration: Optional[int]
+    ip_family: IpFamily
     cpu_request: Optional[str]
     cpu_limit: Optional[str]
     mem_request: Optional[str]
@@ -395,6 +397,7 @@ class ConfConnection(StructParseBaseNamed):
             "type": self.test_type.name,
             "instances": self.instances,
             "reverse": self.reverse,
+            "ip_family": self.ip_family.name,
             "server": [s.serialize() for s in self.server],
             "client": [c.serialize() for c in self.client],
             "plugins": [p.serialize() for p in self.plugins],
@@ -473,6 +476,12 @@ class ConfConnection(StructParseBaseNamed):
                 default=None,
             )
 
+            ip_family = common.structparse_pop_enum(
+                varg.for_key("ip_family"),
+                enum_type=IpFamily,
+                default=IpFamily.IPV4,
+            )
+
             duration_conn = common.structparse_pop_int(
                 varg.for_key("duration"),
                 default=None,
@@ -532,6 +541,7 @@ class ConfConnection(StructParseBaseNamed):
             secondary_network_nad=secondary_network_nad,
             resource_name=resource_name,
             duration=duration_conn,
+            ip_family=ip_family,
             cpu_request=cpu_request,
             cpu_limit=cpu_limit,
             mem_request=mem_request,

--- a/testSettings.py
+++ b/testSettings.py
@@ -19,6 +19,7 @@ class TestSettings:
     cfg_descr: testConfig.ConfigDescriptor
     instance_index: int
     reverse: bool
+    active_ip_family: tftbase.IpFamily = tftbase.IpFamily.IPV4
 
     event_server_alive: threading.Event = dataclasses.field(
         init=False, default_factory=threading.Event
@@ -134,11 +135,15 @@ class TestSettings:
         return self.test_case_id.info.get_client_pod_type(self.node_client.pod_type)
 
     @property
+    def ip_family(self) -> tftbase.IpFamily:
+        return self.connection.ip_family
+
+    @property
     def connection_mode(self) -> tftbase.ConnectionMode:
         return self.test_case_id.info.connection_mode
 
     def get_test_info(self) -> str:
-        return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.test_case_id.info.node_location}
+        return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}, ip_family={self.active_ip_family.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.test_case_id.info.node_location}
         Client Node: {self.node_client.name}
             Tenant={self.client_is_tenant}
             Index={self.client_index}
@@ -151,7 +156,7 @@ class TestSettings:
         direction = ""
         if self.reverse:
             direction = "-REV"
-        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}"
+        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.test_case_id.info.node_location}{direction}-{self.active_ip_family.name}"
 
     def get_test_metadata(self) -> TestMetadata:
         return TestMetadata(
@@ -173,5 +178,6 @@ class TestSettings:
                 is_tenant=self.client_is_tenant,
                 index=self.client_index,
             ),
+            active_ip_family=self.active_ip_family,
             expects_blocked=self.test_case_id.info.expects_blocked,
         )

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -44,6 +44,8 @@ class HttpServer(task.ServerTask):
             "python3",
             "-m",
             "http.server",
+            "--bind",
+            "::",
             "-d",
             "/etc/kubernetes-traffic-flow-tests",
             f"{self.port}",
@@ -79,6 +81,8 @@ class HttpClient(task.ClientTask):
         else:
             server_ip = self.get_target_ip()
             target_port = self.get_target_port()
+            if tftbase.IpFamily.is_ipv6(server_ip):
+                server_ip = f"[{server_ip}]"
             cmd = f"curl --fail -s --connect-timeout {timeout} http://{server_ip}:{target_port}/data"
 
             def _check_success_podman(r: host.Result) -> bool:

--- a/tftbase.py
+++ b/tftbase.py
@@ -261,7 +261,10 @@ def get_udn_localnet_physical_network() -> str:
 
 @functools.cache
 def get_secondary_nad_subnets() -> str:
-    s = get_environ(ENV_TFT_SECONDARY_NAD_SUBNETS) or "10.193.0.0/16/26"
+    s = (
+        get_environ(ENV_TFT_SECONDARY_NAD_SUBNETS)
+        or "10.193.0.0/16/26,fd00:10:193::/48/64"
+    )
     logger.info(f"env: {ENV_TFT_SECONDARY_NAD_SUBNETS}={shlex.quote(s)}")
     return s
 
@@ -380,6 +383,32 @@ def eval_binary_opt_in(
         b = not a
 
     return a, b
+
+
+class IpFamily(Enum):
+    IPV4 = 1
+    IPV6 = 2
+    DUAL_STACK = 3
+
+    def ip_families(self) -> tuple["IpFamily", ...]:
+        if self == IpFamily.DUAL_STACK:
+            return (IpFamily.IPV4, IpFamily.IPV6)
+        return (self,)
+
+    @staticmethod
+    def is_ipv6(addr: str) -> bool:
+        return ":" in addr
+
+    def matches(self, addr: str) -> bool:
+        if self == IpFamily.IPV6:
+            return IpFamily.is_ipv6(addr)
+        return not IpFamily.is_ipv6(addr)
+
+    def pick_ip(self, ips: list[str]) -> Optional[str]:
+        for ip in ips:
+            if self.matches(ip):
+                return ip
+        return None
 
 
 class ClusterMode(Enum):
@@ -616,6 +645,7 @@ class TestMetadata:
     reverse: bool
     server: PodInfo
     client: PodInfo
+    active_ip_family: IpFamily = IpFamily.IPV4
     expects_blocked: bool = False
 
 
@@ -790,9 +820,18 @@ class TftResults:
             return ""
         return f" in {repr(self.filename)}"
 
+    # IPv4 is the historic default; omit it to keep old result files stable.
+    @staticmethod
+    def _serialize_result(result: TftResult) -> dict[str, Any]:
+        data = common.dataclass_to_dict(result)
+        tft_metadata = data["flow_test"]["tft_metadata"]
+        if tft_metadata.get("active_ip_family") == IpFamily.IPV4.name:
+            del tft_metadata["active_ip_family"]
+        return data
+
     def serialize(self) -> dict[str, Any]:
         return {
-            TftResults.TFT_TESTS: [common.dataclass_to_dict(o) for o in self],
+            TftResults.TFT_TESTS: [TftResults._serialize_result(o) for o in self],
         }
 
     def serialize_to_file(

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -387,6 +387,7 @@ class TrafficFlowTests:
         cfg_descr: ConfigDescriptor,
         instance_index: int,
         reverse: bool = False,
+        active_ip_family: tftbase.IpFamily = tftbase.IpFamily.IPV4,
     ) -> TftResult:
         connection = cfg_descr.get_connection()
 
@@ -398,6 +399,7 @@ class TrafficFlowTests:
             cfg_descr=cfg_descr,
             instance_index=instance_index,
             reverse=reverse,
+            active_ip_family=active_ip_family,
         )
         logger.info(f"Starting test {ts.get_test_info()}")
         s, c = connection.test_type_handler.create_server_client(ts)
@@ -485,22 +487,25 @@ class TrafficFlowTests:
             connection = cfg_descr2.get_connection()
             logger.info(f"Starting {connection.name}")
             logger.info(f"Number Of Simultaneous connections {connection.instances}")
-            for instance_index in range(connection.instances):
-                tft_results.append(
-                    self._run_test_case_instance(
-                        cfg_descr2,
-                        instance_index=instance_index,
-                    )
-                )
-                if connection.test_type_handler.can_run_reverse(connection):
+            for active_family in connection.ip_family.ip_families():
+                for instance_index in range(connection.instances):
                     tft_results.append(
                         self._run_test_case_instance(
                             cfg_descr2,
                             instance_index=instance_index,
-                            reverse=True,
+                            active_ip_family=active_family,
                         )
                     )
-                self._cleanup_previous_testspace(cfg_descr2)
+                    if connection.test_type_handler.can_run_reverse(connection):
+                        tft_results.append(
+                            self._run_test_case_instance(
+                                cfg_descr2,
+                                instance_index=instance_index,
+                                reverse=True,
+                                active_ip_family=active_family,
+                            )
+                        )
+                    self._cleanup_previous_testspace(cfg_descr2)
         return tft_results
 
     def _run_test_cases(self, cfg_descr: ConfigDescriptor) -> TftResults:


### PR DESCRIPTION
Add an ip_family connection option so tests can run over IPv4, IPv6, or both families. Keep IPv4 as the default to preserve existing behavior, and include the active family in test metadata, log output, result summaries, and generated test names.

Select pod, service, LoadBalancer, secondary-network, and UDN addresses by the active IP family. For dual-stack connections, run each test once per family so v4 and v6 results are reported separately.

Update HTTP and external/podman paths for IPv6 traffic, including IPv6 URL formatting, HTTP server binding, host route lookup, and podman port publishing. Mark generated Services as PreferDualStack so Kubernetes allocates dual-stack service IPs when available while still falling back to single-stack clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable IP family preferences (IPv4, IPv6, dual-stack) per connection in test configurations
  * Tests now automatically execute across all supported IP families, enhancing test coverage
  * Services are configured with dual-stack IP family preference support

* **Documentation**
  * Updated configuration reference with new `ip_family` field options and examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->