### PR TITLE
Fix using docker for dpu simulator CI lane

### DIFF
--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Deploy KIND cluster
         working-directory: dpu-simulator
+        env:
+          KIND_EXPERIMENTAL_PROVIDER: docker
         run: ./bin/dpu-sim --config ${{ matrix.dpu_sim_config }}
 
       - name: Verify clusters are ready


### PR DESCRIPTION
The CI lane was setting up docker, but then executing dpu-sim with podman. We need to use docker after this PR in dpu simulator has been merged: ovn-kubernetes/dpu-simulator#26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve build infrastructure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->