### PR TITLE
Add timeout to iperf to prevent connection stalling

### DIFF
--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -27,6 +27,7 @@ logger = common.ExtendedLogger("tft." + __name__)
 IPERF_EXE = "iperf3"
 IPERF_UDP_OPT = "-u"
 IPERF_REV_OPT = "-R"
+IPERF_TIMEOUT = 30
 
 
 class ResultTcp:
@@ -139,7 +140,8 @@ class IperfClient(task.ClientTask):
     def _create_task_operation(self) -> TaskOperation:
         server_ip = self.get_target_ip()
         target_port = self.get_target_port()
-        cmd = f"{IPERF_EXE} -c {server_ip} -p {target_port} --json -t {self.get_duration()}"
+        timeout = self.get_duration() + IPERF_TIMEOUT
+        cmd = f"timeout {timeout} {IPERF_EXE} -c {server_ip} -p {target_port} --json -t {self.get_duration()}"
 
         connect_timeout_ms = int(self.get_duration() * 1.5 * 1000)
         cmd += f" --connect-timeout {connect_timeout_ms}"


### PR DESCRIPTION
The `--connection-timeout` field only times out the initial tcp connection start. If iperf fails past this stage, it can lead to stalling of the test suite. 

Added `timeout` for the iperf command to be 30 seconds + iperf connection time. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an automatic timeout guard to network performance test runs to prevent measurements from hanging.
  * Updated the timeout behavior to scale with the configured test duration, improving consistency and ensuring the `iperf3` command terminates reliably after the allotted window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->