### PR TITLE
Add POD_TO_MGMT_PORT test case to verify pod-to-worker ovn-k8s-mp0 reachability

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,26 @@ Test cases 37-59 run traffic over OVN-Kubernetes User Defined Networks. The fram
 
 CIDRs default to `15.1.0.0/16` (primary), `15.2.0.0/16` (secondary), and `15.3.0.0/24` (localnet), overridable via `TFT_UDN_PRIMARY_CIDR`, `TFT_UDN_SECONDARY_CIDR`, and `TFT_UDN_LOCALNET_CIDR`. The localnet physical network name defaults to `physnet`, overridable via `TFT_UDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn-primary.yaml.j2`, `manifests/udn-secondary.yaml.j2`, and `manifests/udn-localnet.yaml.j2`.
 
+## Management Port Reachability Plugin
+
+The `ping_mgmt_port` plugin checks that the client node can reach the `ovn-k8s-mp0`
+management port interface of the server node. The target IP is derived as the `.2`
+address of the server node's `k8s.ovn.org/node-subnets` annotation. Add it to a
+connection's plugin list:
+
+```yaml
+plugins:
+  - ping_mgmt_port
+```
+
+or scoped to specific test cases:
+
+```yaml
+plugins:
+  - name: ping_mgmt_port
+    test_cases: [POD_TO_POD_DIFF_NODE]
+```
+
 ## DPU Mode
 
 When running with a DPU (Data Processing Unit) cluster, the `validate_offload` plugin needs

--- a/pluginPingMgmtPort.py
+++ b/pluginPingMgmtPort.py
@@ -1,0 +1,136 @@
+import ipaddress
+import json
+
+from typing import Any
+from typing import Optional
+
+from ktoolbox import common
+
+import pluginbase
+import task
+import tftbase
+
+from task import PluginTask
+from task import TaskOperation
+from testSettings import TestSettings
+from tftbase import BaseOutput
+from tftbase import PluginOutput
+from tftbase import TaskRole
+
+logger = common.ExtendedLogger("tft." + __name__)
+
+PING_COUNT = 5
+PING_TIMEOUT_SEC = 2
+
+
+def mgmt_port_ip_from_node_subnets(node_subnets_raw: str) -> str:
+    node_subnets = json.loads(node_subnets_raw)
+    subnet = node_subnets["default"][0]
+    network = ipaddress.ip_network(subnet, strict=False)
+    return str(network.network_address + 2)
+
+
+class PluginPingMgmtPort(pluginbase.Plugin):
+    PLUGIN_NAME = "ping_mgmt_port"
+
+    def _enable(
+        self,
+        *,
+        ts: TestSettings,
+        perf_server: task.ServerTask,
+        perf_client: task.ClientTask,
+        tenant: bool,
+    ) -> list[PluginTask]:
+        return [
+            TaskPingMgmtPort(ts, tenant),
+        ]
+
+
+plugin = pluginbase.register_plugin(PluginPingMgmtPort())
+
+
+class TaskPingMgmtPort(PluginTask):
+    @property
+    def plugin(self) -> pluginbase.Plugin:
+        return plugin
+
+    def __init__(self, ts: TestSettings, tenant: bool):
+        super().__init__(
+            ts=ts,
+            index=0,
+            task_role=TaskRole.CLIENT,
+            tenant=tenant,
+        )
+
+        self.pod_name = f"tools-pod-{self.node_location}-client-ping-mgmt-port"
+        self.in_file_template = tftbase.get_manifest("tools-pod.yaml.j2")
+
+    def initialize(self) -> None:
+        super().initialize()
+        self.render_pod_file("Plugin Pod Yaml")
+
+    def _get_mgmt_port_ip(self) -> str:
+        server_node = self.ts.node_server.name
+
+        node_data = self.run_oc_get(f"node/{server_node}", namespace=None)
+        if node_data is None:
+            raise RuntimeError(f"Management port node {server_node!r} not found")
+
+        annotations = node_data.get("metadata", {}).get("annotations", {})
+        node_subnets_raw = annotations.get("k8s.ovn.org/node-subnets")
+        if node_subnets_raw is None:
+            raise RuntimeError(
+                f'Node {server_node!r} has no "k8s.ovn.org/node-subnets" annotation'
+            )
+
+        try:
+            return mgmt_port_ip_from_node_subnets(node_subnets_raw)
+        except (json.JSONDecodeError, KeyError, IndexError, ValueError) as e:
+            raise RuntimeError(
+                f"Could not determine management port IP for node "
+                f"{server_node!r} from node-subnets {node_subnets_raw!r}: {e}"
+            ) from e
+
+    def _create_task_operation(self) -> TaskOperation:
+        def _thread_action() -> BaseOutput:
+            self.ts.clmo_barrier.wait()
+
+            mgmt_ip = self._get_mgmt_port_ip()
+            cmd = f"ping -c {PING_COUNT} -W {PING_TIMEOUT_SEC} {mgmt_ip}"
+            r = self.run_oc_exec(cmd, may_fail=True)
+
+            success = r.success
+            msg: Optional[str] = None
+            result: dict[str, Any] = {
+                "mgmt_port_ip": mgmt_ip,
+                "server_node": self.ts.node_server.name,
+                "cmd": common.dataclass_to_dict(r),
+            }
+
+            if not success:
+                msg = (
+                    f"Ping to management port {mgmt_ip} on node "
+                    f"{self.ts.node_server.name} failed: {r.err}"
+                )
+
+            return PluginOutput(
+                success=success,
+                msg=msg,
+                plugin_metadata=self.get_plugin_metadata(),
+                command=cmd,
+                result=result,
+            )
+
+        return TaskOperation(
+            log_name=self.log_name,
+            thread_action=_thread_action,
+        )
+
+    def _aggregate_output_log_success(
+        self,
+        result: tftbase.AggregatableOutput,
+    ) -> None:
+        assert isinstance(result, PluginOutput)
+        mgmt_ip = result.result.get("mgmt_port_ip", "unknown")
+        server = result.result.get("server_node", "unknown")
+        logger.info(f"Ping to management port {mgmt_ip} on node {server} succeeded")

--- a/pluginPingMgmtPort.py
+++ b/pluginPingMgmtPort.py
@@ -95,7 +95,18 @@ class TaskPingMgmtPort(PluginTask):
         def _thread_action() -> BaseOutput:
             self.ts.clmo_barrier.wait()
 
-            mgmt_ip = self._get_mgmt_port_ip()
+            try:
+                mgmt_ip = self._get_mgmt_port_ip()
+            except RuntimeError as e:
+                logger.error(str(e))
+                return PluginOutput(
+                    success=False,
+                    msg=str(e),
+                    plugin_metadata=self.get_plugin_metadata(),
+                    command="",
+                    result={},
+                )
+
             cmd = f"ping -c {PING_COUNT} -W {PING_TIMEOUT_SEC} {mgmt_ip}"
             r = self.run_oc_exec(cmd, may_fail=True)
 

--- a/pluginbase.py
+++ b/pluginbase.py
@@ -75,6 +75,7 @@ def _get_plugin_registry() -> dict[str, Plugin]:
     # when being imported. Ensure they are imported.
     import pluginMeasureCpu  # noqa: F401
     import pluginMeasurePower  # noqa: F401
+    import pluginPingMgmtPort  # noqa: F401
     import pluginValidateOffload  # noqa: F401
 
     return _plugin_registry

--- a/tests/test_pluginPingMgmtPort.py
+++ b/tests/test_pluginPingMgmtPort.py
@@ -1,0 +1,39 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pluginPingMgmtPort  # noqa: E402
+
+
+def test_mgmt_port_ip_from_node_subnets() -> None:
+    assert (
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets(
+            json.dumps({"default": ["10.131.0.0/23"]})
+        )
+        == "10.131.0.2"
+    )
+    assert (
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets(
+            json.dumps({"default": ["10.130.0.0/24"]})
+        )
+        == "10.130.0.2"
+    )
+
+
+def test_mgmt_port_ip_from_node_subnets_invalid() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets("not json")
+    with pytest.raises(KeyError):
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets(
+            json.dumps({"other": ["10.0.0.0/24"]})
+        )
+    with pytest.raises(IndexError):
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets(json.dumps({"default": []}))
+    with pytest.raises(ValueError):
+        pluginPingMgmtPort.mgmt_port_ip_from_node_subnets(
+            json.dumps({"default": ["not-a-subnet"]})
+        )


### PR DESCRIPTION
Adds test case 69 (`POD_TO_MGMT_PORT`) with a new ping connection type, verifying that a pod on one node can reach another node's ovn-k8s-mp0 management-port IP, catching a control-plane-to-worker mp0 unreachability issue we've observed several times in DPF clusters.

How it works:
- Client is a normal pod scheduled on the client: node
- No server pod is created (new `ConnectionMode.MGMT_PORT_IP` short-circuits server provisioning, like `EXTERNAL_IP` does).
- Target IP is derived from the server: node's `k8s.ovn.org/node-subnets` annotation (.2 address = mp0 convention).
- Client runs `ping -c 5 -W 2 <mp0-ip>`; pass/fail is exit code, no throughput involved.

Verified: black/flake8/mypy clean, 48/48 unit tests pass, and live end-to-end run against a real cluster (control-plane client → worker mp0) succeeded.

Example config file:
```yaml
tft:
  - name: "Mgmt Port Reachability Test"
    namespace: "tft-mgmt-port-test"
    test_cases: "69"
    duration: "5"
    connections:
      - name: "Connection_1"
        type: "ping"
        instances: 1
        server:
          - name: "worker1"
        client:
          - name: "master1"
kubeconfig: "~/.kube/config"
```

Assisted-by: Claude 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `ping_mgmt_port` plugin that verifies management-port reachability by pinging the server node from a tools pod.
  * Supports enabling the plugin globally or restricting it to specific test cases.
  * Automatically derives the target management IP from the server node’s subnet annotation.

* **Documentation**
  * Documented the `ping_mgmt_port` plugin, including configuration guidance and YAML examples.

* **Tests**
  * Added coverage for correct management IP derivation and validation of malformed/invalid annotation inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->