### PR TITLE
Use mypy version 2.1.0 instead of latest version

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 black
 flake8
-mypy
+mypy==2.1.0
 pytest
 types-PyYAML
 types-paramiko


### PR DESCRIPTION
Mypy 2.2.0 leading to failures for very old code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency settings by removing an inherited requirements reference.
  * Pinned the type-checking tool to a specific version for more consistent development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->