### PR TITLE
Remove ci-change branch from ci lane

### DIFF
--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - ci-change
 
 jobs:
   kind-tft:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers so checks now run only on pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->