### PR TITLE
iperf: auto-detect IP family for ClusterIP, add ip_family config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tft:
     test_cases: "(3)"
     duration: "(4)"
     pre_provision: (5)
+    ip_family: "(33)"
     # Location of artifacts from run can be specified: default <working-dir>/ft-logs/
     # logs: "/tmp/ft-logs"
     connections:
@@ -203,7 +204,12 @@ kubeconfig_infra: (32)
 32. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
-33. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
+33. "ip_family" - (Optional) Controls the `-4`/`-6` flag passed to iperf3. Accepted values:
+     `"auto"` (default), `"ipv4"`, `"ipv6"`, `"any"`. When set to `"auto"`, the IP family is
+     detected from the actual ClusterIP service address for ClusterIP connection modes; for
+     other connection modes no flag is passed. Set explicitly to `"ipv4"` or `"ipv6"` to force
+     the IP family regardless of connection mode, or `"any"` to let iperf3 auto-detect.
+34. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
   which host worker node they belong to. For NVIDIA DPUs, use `provisioning.dpu.nvidia.com/host`.
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,11 @@ tft:
     # i.e. "1-9,15-19" or using the pretty names.
     test_cases: "1"
     duration: "30"
+    # ip_family: "auto" (default), "ipv4", "ipv6", or "any".
+    # Controls the -4/-6 flag passed to iperf3.
+    # "auto" detects the IP family from the ClusterIP service address;
+    # for non-ClusterIP connections it passes no flag.
+    # ip_family: "auto"
     # "logs": location of test results. Defaults to "<working-dir>/ft-logs/".
     # It is better to pass "--output-base" to ./tft.py.
     # "privileged_pod": whether to run test pods as privileged. Defaults to false.

--- a/testConfig.py
+++ b/testConfig.py
@@ -29,6 +29,7 @@ from ktoolbox.k8sClient import K8sClient
 from pluginbase import Plugin
 from testType import TestTypeHandler
 from tftbase import ClusterMode
+from tftbase import IpFamily
 from tftbase import PodType
 from tftbase import TestCaseType
 from tftbase import TestType
@@ -604,6 +605,7 @@ class ConfTest(StructParseBaseNamed):
     capabilities_pod: Mapping[str, tuple[str, ...]]
     connections: tuple[ConfConnection, ...]
     logs: pathlib.Path
+    ip_family: IpFamily
 
     def __post_init__(self) -> None:
         for c in self.connections:
@@ -624,6 +626,7 @@ class ConfTest(StructParseBaseNamed):
             "capabilities_pod": self.capabilities_pod,
             "connections": [c.serialize() for c in self.connections],
             "logs": str(self.logs),
+            "ip_family": self.ip_family.value,
         }
 
     @staticmethod
@@ -689,6 +692,12 @@ class ConfTest(StructParseBaseNamed):
                 default="ft-logs",
             )
 
+            ip_family = common.structparse_pop_enum(
+                varg.for_key("ip_family"),
+                enum_type=IpFamily,
+                default=IpFamily.AUTO,
+            )
+
         return ConfTest(
             yamlidx=pctx.yamlidx,
             yamlpath=pctx.yamlpath,
@@ -701,6 +710,7 @@ class ConfTest(StructParseBaseNamed):
             capabilities_pod=capabilities_pod,
             connections=connections,
             logs=pathlib.Path(logs),
+            ip_family=ip_family,
         )
 
     @property

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import shlex
 import task
@@ -18,7 +19,9 @@ from testSettings import TestSettings
 from testType import TestTypeHandler
 from tftbase import BaseOutput
 from tftbase import Bitrate
+from tftbase import ConnectionMode
 from tftbase import FlowTestOutput
+from tftbase import IpFamily
 from tftbase import TestType
 
 logger = common.ExtendedLogger("tft." + __name__)
@@ -109,6 +112,25 @@ TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_TCP))
 TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_UDP))
 
 
+def _resolve_ip_family_opt(
+    ip_family: IpFamily,
+    connection_mode: ConnectionMode,
+    server: "task.ServerTask",
+) -> str:
+    if ip_family != IpFamily.AUTO:
+        return ip_family.iperf_opt
+    if connection_mode != ConnectionMode.CLUSTER_IP:
+        return ""
+    cluster_ip = server.get_cluster_ip()
+    if cluster_ip is None:
+        return ""
+    try:
+        addr = ipaddress.ip_address(cluster_ip.strip())
+    except ValueError:
+        return ""
+    return "-4" if addr.version == 4 else "-6"
+
+
 class IperfServer(task.ServerTask):
     def cmd_line_args(self, *, for_template: bool = False) -> list[str]:
         if for_template:
@@ -116,8 +138,15 @@ class IperfServer(task.ServerTask):
         else:
             extra_args = ["--one-off", "--json"]
         server_args = self.ts.cfg_descr.get_server().args or ()
+        ip_opt = _resolve_ip_family_opt(
+            self.ts.cfg_descr.get_tft().ip_family,
+            self.connection_mode,
+            self,
+        )
+        ip_args = [ip_opt] if ip_opt else []
         return [
             IPERF_EXE,
+            *ip_args,
             "-s",
             "-p",
             f"{self.port}",
@@ -141,7 +170,13 @@ class IperfClient(task.ClientTask):
         server_ip = self.get_target_ip()
         target_port = self.get_target_port()
         timeout = self.get_duration() + IPERF_TIMEOUT
-        cmd = f"timeout {timeout} {IPERF_EXE} -c {server_ip} -p {target_port} --json -t {self.get_duration()}"
+        ip_opt = _resolve_ip_family_opt(
+            self.ts.cfg_descr.get_tft().ip_family,
+            self.connection_mode,
+            self.server,
+        )
+        ip_opt_str = f" {ip_opt}" if ip_opt else ""
+        cmd = f"timeout {timeout} {IPERF_EXE}{ip_opt_str} -c {server_ip} -p {target_port} --json -t {self.get_duration()}"
 
         connect_timeout_ms = int(self.get_duration() * 1.5 * 1000)
         cmd += f" --connect-timeout {connect_timeout_ms}"

--- a/tftbase.py
+++ b/tftbase.py
@@ -567,6 +567,21 @@ class ConnectionMode(Enum):
     NP_NS_SELECTOR_ALLOW = 15
 
 
+class IpFamily(Enum):
+    AUTO = "auto"
+    IPV4 = "ipv4"
+    IPV6 = "ipv6"
+    ANY = "any"
+
+    @property
+    def iperf_opt(self) -> str:
+        if self == IpFamily.IPV4:
+            return "-4"
+        if self == IpFamily.IPV6:
+            return "-6"
+        return ""
+
+
 class TargetAccessMode(Enum):
     IP = 1
     SERVICE_NAME = 2


### PR DESCRIPTION
## Summary
- Auto-detect the IP family from the actual ClusterIP service address and pass `-4` or `-6` to iperf3 accordingly. This prevents "Bad file descriptor" errors caused by iperf3 attempting IPv6 on IPv4-only services (or vice versa).
- Add an `ip_family` config option (default: `"auto"`) allowing users to explicitly force `"ipv4"`, `"ipv6"`, or `"any"` (no flag) when needed.
- When `ip_family` is `"auto"` and connection mode is not `CLUSTER_IP`, no flag is passed (original behavior).

## Behavior
| `ip_family` | ClusterIP (IPv4 svc) | ClusterIP (IPv6 svc) | Other modes |
|---|---|---|---|
| `"auto"` (default) | `-4` | `-6` | no flag |
| `"ipv4"` | `-4` | `-4` | `-4` |
| `"ipv6"` | `-6` | `-6` | `-6` |
| `"any"` | no flag | no flag | no flag |

## Test plan
- [ ] Run HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE iperf test on a cluster with IPv6 addresses on host interfaces and IPv4 ClusterIP
- [ ] Verify non-ClusterIP iperf tests still work without any flag
- [ ] Verify explicit `ip_family: "ipv6"` overrides auto-detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iperf3 connectivity for ClusterIP connections by automatically selecting the correct iperf3 IPv4/IPv6 flag on both server and client.
  * Kept existing behavior for non-ClusterIP connection modes and for explicitly configured IP family values.
* **New Features**
  * Added optional `ip_family` configuration for `tft`, supporting `auto` (default), `ipv4`, `ipv6`, and `any`, with inline documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->