### PR TITLE
Default service access point to IP instead of SERVICE_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,8 +444,8 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_KUBECONFIG`, `TFT_KUBECONFIG_INFRA` to overwrite the kubeconfigs from the configuration
      file. See also the "--kubeconfig" and "--kubeconfig-infra" command line options.
 - `TFT_DEFAULT_TARGET_ACCESS_MODE` controls the normal target access mode for service-backed
-     tests. Defaults to `SERVICE_NAME`; set to `IP` to use service IPs instead of service DNS
-     names. Accepted values are `IP` and `SERVICE_NAME`.
+     tests. Defaults to `IP`; set to `SERVICE_NAME` to use service DNS names instead of service
+     IPs. Accepted values are `IP` and `SERVICE_NAME`.
 - `TFT_ENABLE_TARGET_ACCESS_SUBTESTS` enables extra target access variants for service-backed
      tests. Defaults to `false`; when `true`, ClusterIP and LoadBalancer tests run both
      `IP` and `SERVICE_NAME`, while NodePort tests also include `SERVER_NODE_IP`.

--- a/tftbase.py
+++ b/tftbase.py
@@ -587,9 +587,7 @@ def get_default_target_access_mode(
     if connection_mode in _SERVICE_TARGET_ACCESS_CONNECTION_MODES:
         if override is not None:
             return override
-        if connection_mode == ConnectionMode.NODE_PORT_IP:
-            return TargetAccessMode.SERVER_NODE_IP
-        return TargetAccessMode.SERVICE_NAME
+        return TargetAccessMode.IP
     return TargetAccessMode.IP
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default target access mode for service-related connections to use service IP addresses.
  * Preserved support for explicitly selecting service DNS names through the environment variable.

* **Documentation**
  * Corrected the documented default for `TFT_DEFAULT_TARGET_ACCESS_MODE` to `IP`.
  * Clarified the available values and their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->