### PR TITLE
Make pod bring-up timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_HOST_NETWORK_NAMESPACE` the namespace used as the `namespaceSelector` target for the
      `HOST_TO_POD_NP_NS_SELECTOR_ALLOW` test case. Defaults to `ovn-host-network`.
      For OpenShift clusters, it must be set to `openshift-host-network`.
+- `TFT_POD_BRINGUP_TIMEOUT` controls how long TFT waits for a pod to become ready. Accepts a
+     Kubernetes duration such as `30s` or `5m`. Defaults to `2m`.
 
 ## File Transfer via magic-wormhole
 

--- a/task.py
+++ b/task.py
@@ -1029,14 +1029,17 @@ class Task(ABC):
         else:
             logger.info(f"Pod {self.pod_name} already exists.")
 
-        logger.info(f"Waiting for Pod {self.pod_name} to become ready.")
+        timeout = tftbase.get_tft_pod_bringup_timeout()
+        logger.info(f"Waiting up to {timeout} for Pod {self.pod_name} to become ready.")
         r = self.run_oc(
-            f"wait --for=condition=ready pod/{self.pod_name} --timeout=2m",
+            f"wait --for=condition=ready pod/{self.pod_name} "
+            f"--timeout={shlex.quote(timeout)}",
             may_fail=True,
         )
         if not r.success:
-            self._dump_pod_failure_diagnostics(reason="did not become Ready within 2m")
-            raise RuntimeError(f"Pod {self.pod_name} did not become Ready within 2m")
+            reason = f"did not become Ready within {timeout}"
+            self._dump_pod_failure_diagnostics(reason=reason)
+            raise RuntimeError(f"Pod {self.pod_name} {reason}")
 
     def _dump_pod_failure_diagnostics(self, *, reason: str) -> None:
         sep = "=" * 64

--- a/tftbase.py
+++ b/tftbase.py
@@ -39,6 +39,7 @@ ENV_TFT_EXTERNAL_URL = "TFT_EXTERNAL_URL"
 ENV_TFT_EXTERNAL_SERVER_STRING = "TFT_EXTERNAL_SERVER_STRING"
 
 ENV_TFT_HOST_NETWORK_NAMESPACE = "TFT_HOST_NETWORK_NAMESPACE"
+ENV_TFT_POD_BRINGUP_TIMEOUT = "TFT_POD_BRINGUP_TIMEOUT"
 
 ENV_TFT_LOG_PREAMBLE = "TFT_LOG_PREAMBLE"
 ENV_TFT_ENABLE_TARGET_ACCESS_SUBTESTS = "TFT_ENABLE_TARGET_ACCESS_SUBTESTS"
@@ -248,6 +249,13 @@ def get_tft_external_server_string() -> Optional[str]:
     d = get_environ(ENV_TFT_EXTERNAL_SERVER_STRING)
     logger.info(f"env: {ENV_TFT_EXTERNAL_SERVER_STRING}={shlex.quote(d or '')}")
     return d or None
+
+
+@functools.cache
+def get_tft_pod_bringup_timeout() -> str:
+    timeout = get_environ(ENV_TFT_POD_BRINGUP_TIMEOUT) or "2m"
+    logger.info(f"env: {ENV_TFT_POD_BRINGUP_TIMEOUT}={shlex.quote(timeout)}")
+    return timeout
 
 
 TFT_TESTS = "tft-tests"


### PR DESCRIPTION
Add TFT_POD_BRINGUP_TIMEOUT to control how long TFT waits for pods to become ready. Keep 2m as the default and use the configured value in readiness logs and errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for waiting for pods to become ready.
  * Supports Kubernetes duration formats such as `30s` and `5m`.
  * Defaults to a two-minute timeout when no value is configured.

* **Bug Fixes**
  * Timeout-related readiness errors now report the configured duration for clearer diagnostics.

* **Documentation**
  * Documented the new `TFT_POD_BRINGUP_TIMEOUT` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->