### PR TITLE
Support multiple cluster subnets for primary UDNs and custom host subnet

### DIFF
--- a/.github/workflows/kind-tft.yml
+++ b/.github/workflows/kind-tft.yml
@@ -18,6 +18,7 @@ jobs:
             tft_config: ""
             tft_env: |
               TFT_ENABLE_TARGET_ACCESS_SUBTESTS=true
+              TFT_UDN_PRIMARY_CIDR=15.1.0.0/17/24,15.1.128.0/17/24
           - scenario: diverse-subset
             dpu_sim_config: ci/config-kind.yaml
             tft_config: .github/tft-configs/diverse-subset.yaml

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks
   - **76-77**: Layer2 UDN.
   - **78-79**: Localnet CUDN.
 
-The primary CIDR defaults to `15.1.0.0/16` with host subnet `24`. It can include a custom host subnet length as `15.1.0.0/16/24`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
+The primary CIDR defaults to `15.1.0.0/16` with host subnet `24`. `TFT_UDN_PRIMARY_CIDR` accepts comma-separated entries, for example `15.1.0.0/17/24,15.1.128.0/17/24`. Each entry can include an optional host subnet length as `15.1.0.0/16/24`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
 
 `udn_primary_network` supports `mode` values `udn` and `cudn`, `topology` values `layer3` and `layer2`, and `transport` values `overlay` and `no-overlay`. `no-overlay` requires `mode: cudn` and `topology: layer3`.
 
@@ -479,7 +479,7 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_ENABLE_TARGET_ACCESS_SUBTESTS` enables extra target access variants for service-backed
      tests. Defaults to `false`; when `true`, ClusterIP and LoadBalancer tests run both
      `IP` and `SERVICE_NAME`, while NodePort tests also include `SERVER_NODE_IP`.
-- `TFT_UDN_PRIMARY_CIDR` CIDR for primary UDN tests. Supports an optional host subnet length, e.g. `15.1.0.0/16/24`. Defaults to `15.1.0.0/16` with host subnet `24`.
+- `TFT_UDN_PRIMARY_CIDR` comma-separated CIDR entries for primary UDN tests, e.g. `15.1.0.0/17/24,15.1.128.0/17/24`. Each entry supports an optional host subnet length, e.g. `15.1.0.0/16/24`; entries without one use `24`. Defaults to a single `15.1.0.0/16` entry.
 - `TFT_CUDN_SECONDARY_LAYER3_CIDR` CIDR for secondary Layer3 CUDN tests. Defaults to `15.2.0.0/16`.
 - `TFT_UDN_SECONDARY_LAYER3_CIDR` CIDR for secondary Layer3 UDN tests. Defaults to `15.3.0.0/16`.
 - `TFT_CUDN_SECONDARY_LAYER2_CIDR` CIDR for secondary Layer2 CUDN tests. Defaults to `15.4.0.0/16`.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks
   - **76-77**: Layer2 UDN.
   - **78-79**: Localnet CUDN.
 
-The primary CIDR defaults to `15.1.0.0/16`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
+The primary CIDR defaults to `15.1.0.0/16` with host subnet `24`. It can include a custom host subnet length as `15.1.0.0/16/24`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
 
 `udn_primary_network` supports `mode` values `udn` and `cudn`, `topology` values `layer3` and `layer2`, and `transport` values `overlay` and `no-overlay`. `no-overlay` requires `mode: cudn` and `topology: layer3`.
 
@@ -479,7 +479,7 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_ENABLE_TARGET_ACCESS_SUBTESTS` enables extra target access variants for service-backed
      tests. Defaults to `false`; when `true`, ClusterIP and LoadBalancer tests run both
      `IP` and `SERVICE_NAME`, while NodePort tests also include `SERVER_NODE_IP`.
-- `TFT_UDN_PRIMARY_CIDR` CIDR for primary UDN tests. Defaults to `15.1.0.0/16`.
+- `TFT_UDN_PRIMARY_CIDR` CIDR for primary UDN tests. Supports an optional host subnet length, e.g. `15.1.0.0/16/24`. Defaults to `15.1.0.0/16` with host subnet `24`.
 - `TFT_CUDN_SECONDARY_LAYER3_CIDR` CIDR for secondary Layer3 CUDN tests. Defaults to `15.2.0.0/16`.
 - `TFT_UDN_SECONDARY_LAYER3_CIDR` CIDR for secondary Layer3 UDN tests. Defaults to `15.3.0.0/16`.
 - `TFT_CUDN_SECONDARY_LAYER2_CIDR` CIDR for secondary Layer2 CUDN tests. Defaults to `15.4.0.0/16`.

--- a/manifests/cudn.yaml.j2
+++ b/manifests/cudn.yaml.j2
@@ -22,19 +22,25 @@ spec:
     layer3:
       role: {{ network_type }}
       subnets:
-      - cidr: {{ cidr }}
-        hostSubnet: {{ host_subnet }}
+{% for subnet in subnets %}
+      - cidr: {{ subnet.cidr }}
+        hostSubnet: {{ subnet.host_subnet }}
+{% endfor %}
 {% elif topology_name == "Layer2" %}
     layer2:
       role: {{ network_type }}
       subnets:
-      - {{ cidr }}
+{% for subnet in subnets %}
+      - {{ subnet.cidr }}
+{% endfor %}
 {% elif topology_name == "Localnet" %}
     localnet:
       role: {{ network_type }}
       physicalNetworkName: {{ physical_network_name }}
       subnets:
-      - {{ cidr }}
+{% for subnet in subnets %}
+      - {{ subnet.cidr }}
+{% endfor %}
 {% endif %}
 {% if transport_name == "NoOverlay" %}
     transport: NoOverlay

--- a/manifests/cudn.yaml.j2
+++ b/manifests/cudn.yaml.j2
@@ -23,7 +23,7 @@ spec:
       role: {{ network_type }}
       subnets:
       - cidr: {{ cidr }}
-        hostSubnet: 24
+        hostSubnet: {{ host_subnet }}
 {% elif topology_name == "Layer2" %}
     layer2:
       role: {{ network_type }}

--- a/manifests/udn.yaml.j2
+++ b/manifests/udn.yaml.j2
@@ -16,11 +16,15 @@ spec:
   layer3:
     role: {{ network_type }}
     subnets:
-    - cidr: {{ cidr }}
-      hostSubnet: {{ host_subnet }}
+{% for subnet in subnets %}
+    - cidr: {{ subnet.cidr }}
+      hostSubnet: {{ subnet.host_subnet }}
+{% endfor %}
 {% elif topology_name == "Layer2" %}
   layer2:
     role: {{ network_type }}
     subnets:
-    - {{ cidr }}
+{% for subnet in subnets %}
+    - {{ subnet.cidr }}
+{% endfor %}
 {% endif %}

--- a/manifests/udn.yaml.j2
+++ b/manifests/udn.yaml.j2
@@ -17,7 +17,7 @@ spec:
     role: {{ network_type }}
     subnets:
     - cidr: {{ cidr }}
-      hostSubnet: 24
+      hostSubnet: {{ host_subnet }}
 {% elif topology_name == "Layer2" %}
   layer2:
     role: {{ network_type }}

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -283,6 +283,19 @@ def test_get_manifest() -> None:
     assert os.path.exists(f)
 
 
+def test_udn_primary_cidr_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        tftbase.ENV_TFT_UDN_PRIMARY_CIDR,
+        "10.10.0.0/16/24, 10.11.0.0/16/25",
+    )
+    tftbase.get_udn_primary_subnets.cache_clear()
+
+    assert tftbase.get_udn_primary_subnets() == (
+        ("10.10.0.0/16", 24),
+        ("10.11.0.0/16", 25),
+    )
+
+
 def test_str_sanitize() -> None:
     assert tftbase.str_sanitize("") == ""
     assert tftbase.str_sanitize("hello!wo_rld@12.3") == "hello-z21-wo-z5f-rld-z40-12-03"

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -294,6 +294,7 @@ def test_udn_primary_cidr_list(monkeypatch: pytest.MonkeyPatch) -> None:
         ("10.10.0.0/16", 24),
         ("10.11.0.0/16", 25),
     )
+    tftbase.get_udn_primary_subnets.cache_clear()
 
 
 def test_str_sanitize() -> None:

--- a/tftbase.py
+++ b/tftbase.py
@@ -274,6 +274,7 @@ ENV_TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED = (
     "TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED"
 )
 ENV_TFT_UDN_NO_OVERLAY_ROUTING_MANAGED = "TFT_UDN_NO_OVERLAY_ROUTING_MANAGED"
+UDN_DEFAULT_HOST_SUBNET = 24
 
 ENV_TFT_SECONDARY_NAD_SUBNETS = "TFT_SECONDARY_NAD_SUBNETS"
 ENV_TFT_SECONDARY_NAD_MTU = "TFT_SECONDARY_NAD_MTU"
@@ -281,10 +282,22 @@ ENV_TFT_SECONDARY_NAD_TOPOLOGY = "TFT_SECONDARY_NAD_TOPOLOGY"
 
 
 @functools.cache
-def get_udn_primary_cidr() -> str:
+def _get_udn_primary_cidr_parts() -> tuple[str, int]:
     s = get_environ(ENV_TFT_UDN_PRIMARY_CIDR) or "15.1.0.0/16"
     logger.info(f"env: {ENV_TFT_UDN_PRIMARY_CIDR}={shlex.quote(s)}")
-    return s
+    cidr, separator, host_subnet = s.rpartition("/")
+    if separator and "/" in cidr:
+        return cidr, int(host_subnet)
+    return s, UDN_DEFAULT_HOST_SUBNET
+
+
+def get_udn_primary_cidr() -> str:
+    return _get_udn_primary_cidr_parts()[0]
+
+
+@functools.cache
+def get_udn_primary_host_subnet() -> int:
+    return _get_udn_primary_cidr_parts()[1]
 
 
 @functools.cache

--- a/tftbase.py
+++ b/tftbase.py
@@ -281,23 +281,20 @@ ENV_TFT_SECONDARY_NAD_MTU = "TFT_SECONDARY_NAD_MTU"
 ENV_TFT_SECONDARY_NAD_TOPOLOGY = "TFT_SECONDARY_NAD_TOPOLOGY"
 
 
-@functools.cache
-def _get_udn_primary_cidr_parts() -> tuple[str, int]:
-    s = get_environ(ENV_TFT_UDN_PRIMARY_CIDR) or "15.1.0.0/16"
-    logger.info(f"env: {ENV_TFT_UDN_PRIMARY_CIDR}={shlex.quote(s)}")
+def _parse_udn_primary_subnet(s: str) -> tuple[str, int]:
     cidr, separator, host_subnet = s.rpartition("/")
     if separator and "/" in cidr:
         return cidr, int(host_subnet)
     return s, UDN_DEFAULT_HOST_SUBNET
 
 
-def get_udn_primary_cidr() -> str:
-    return _get_udn_primary_cidr_parts()[0]
-
-
 @functools.cache
-def get_udn_primary_host_subnet() -> int:
-    return _get_udn_primary_cidr_parts()[1]
+def get_udn_primary_subnets() -> tuple[tuple[str, int], ...]:
+    s = get_environ(ENV_TFT_UDN_PRIMARY_CIDR) or "15.1.0.0/16"
+    logger.info(f"env: {ENV_TFT_UDN_PRIMARY_CIDR}={shlex.quote(s)}")
+    return tuple(
+        _parse_udn_primary_subnet(cidr.strip()) for cidr in s.split(",") if cidr.strip()
+    )
 
 
 @functools.cache

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -136,8 +136,7 @@ class TrafficFlowTests:
         network: testConfig.ConfUdnNetwork,
         network_name: str,
         is_primary: bool,
-        cidr: str,
-        host_subnet: int = tftbase.UDN_DEFAULT_HOST_SUBNET,
+        subnets: tuple[tuple[str, int], ...],
     ) -> None:
         client = cfg_descr.tc.client_tenant
         network_label = network_name
@@ -180,8 +179,10 @@ class TrafficFlowTests:
                 "topology": _j(topology_name),
                 "topology_name": topology_name,
                 "network_type": _j("Primary" if is_primary else "Secondary"),
-                "cidr": _j(cidr),
-                "host_subnet": host_subnet,
+                "subnets": [
+                    {"cidr": _j(cidr), "host_subnet": host_subnet}
+                    for cidr, host_subnet in subnets
+                ],
                 "physical_network_name": _j(physical_network_name),
                 "transport_name": transport_name,
                 "no_overlay_outbound_snat": _j(no_overlay_outbound_snat),
@@ -260,8 +261,7 @@ class TrafficFlowTests:
                 network=tft.udn_primary_network,
                 network_name=tftbase.UDN_PRIMARY_NETWORK_NAME,
                 is_primary=True,
-                cidr=tftbase.get_udn_primary_cidr(),
-                host_subnet=tftbase.get_udn_primary_host_subnet(),
+                subnets=tftbase.get_udn_primary_subnets(),
             )
 
         for network in secondary_networks.values():
@@ -279,7 +279,7 @@ class TrafficFlowTests:
                 network=network_config,
                 network_name=network.name,
                 is_primary=False,
-                cidr=network.get_cidr(),
+                subnets=((network.get_cidr(), tftbase.UDN_DEFAULT_HOST_SUBNET),),
             )
 
         self._configure_namespace(cfg_descr, namespace=udn_ns)

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -137,6 +137,7 @@ class TrafficFlowTests:
         network_name: str,
         is_primary: bool,
         cidr: str,
+        host_subnet: int = tftbase.UDN_DEFAULT_HOST_SUBNET,
     ) -> None:
         client = cfg_descr.tc.client_tenant
         network_label = network_name
@@ -180,6 +181,7 @@ class TrafficFlowTests:
                 "topology_name": topology_name,
                 "network_type": _j("Primary" if is_primary else "Secondary"),
                 "cidr": _j(cidr),
+                "host_subnet": host_subnet,
                 "physical_network_name": _j(physical_network_name),
                 "transport_name": transport_name,
                 "no_overlay_outbound_snat": _j(no_overlay_outbound_snat),
@@ -259,6 +261,7 @@ class TrafficFlowTests:
                 network_name=tftbase.UDN_PRIMARY_NETWORK_NAME,
                 is_primary=True,
                 cidr=tftbase.get_udn_primary_cidr(),
+                host_subnet=tftbase.get_udn_primary_host_subnet(),
             )
 
         for network in secondary_networks.values():


### PR DESCRIPTION
## Summary

Allow primary UDN tests to use multiple cluster subnets with configurable
host-subnet lengths.

- Accept comma-separated subnets through `TFT_UDN_PRIMARY_CIDR`.
- Support an optional host-subnet length for each CIDR using
  `CIDR/hostSubnet` syntax.
- Continue defaulting the host-subnet length to `24` when it is omitted.
- Render all configured subnets in the UDN and CUDN manifests.
- Exercise a two-subnet primary UDN in the Kind full-suite CI lane.

For example:

```text
TFT_UDN_PRIMARY_CIDR=10.10.0.0/16/24,10.11.0.0/16/25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring multiple primary UDN subnets via `TFT_UDN_PRIMARY_CIDR`.
  - Primary subnet entries can now include an optional host subnet length (e.g., `/16/24`).
  - Network manifests now render one subnet block per configured subnet across supported topology modes.

- **Documentation**
  - Updated guidance for `TFT_UDN_PRIMARY_CIDR` to clarify optional host subnet syntax and list formatting.

- **Bug Fixes**
  - Improved primary UDN parsing and provisioning to correctly handle comma-separated CIDR lists.

- **Tests**
  - Added a unit test covering primary UDN CIDR list parsing.

- **Chores**
  - Updated CI workflow to use the new primary UDN CIDR list format in the full test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->