### PR TITLE
Add Uplink and target VRF support for primary CUDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,18 @@ tft:
     privileged_pod: (30)
     capabilities_pod: (31)
     udn_primary_network: # (32)
-      mode: "(33)"
-      topology: "(34)"
-      transport: "(35)"
-      frr_configuration_selector: # (36)
-        "(37)": "(38)"
-kubeconfig: (39)
-kubeconfig_infra: (39)
-dpu_node_host_label: (40)
+      name: "(33)"
+      mode: "(34)"
+      topology: "(35)"
+      transport: "(36)"
+      uplink_name: "(37)"
+      route_advertisement: # (38)
+        targetVRF: "(39)"
+        frr_configuration_selector: # (40)
+          "(41)": "(42)"
+kubeconfig: (43)
+kubeconfig_infra: (43)
+dpu_node_host_label: (44)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -206,16 +210,20 @@ dpu_node_host_label: (40)
 30. "privileged_pod" - (Optional) - Whether to run test pods as privileged. Defaults to false. Can be set at test level or per-node (server/client).
 31. "capabilities_pod" - (Optional) - Linux capabilities for test pods. Format: `{"add": ["NET_ADMIN", "SYS_TIME"]}`. Can be set at test level (applies to all pods) or per-node (server/client) for fine-grained control. Per-node settings take precedence over test-level settings.
 32. "udn_primary_network" - (Optional) Test-level network configuration for primary UDN test cases. Defaults to `mode: udn`, `topology: layer3`, and `transport: overlay`.
-33. "mode" - (Optional) Field under `udn_primary_network`. Supported values are `udn` and `cudn`.
-34. "topology" - (Optional) Field under `udn_primary_network`. Supported values are `layer3` and `layer2`.
-35. "transport" - (Optional) Field under `udn_primary_network`. Supported values are `overlay` and `no-overlay`; `no-overlay` requires `mode: cudn` and `topology: layer3`.
-36. "frr_configuration_selector" - (Optional) Field under `udn_primary_network`. Map of `frrConfigurationSelector.matchLabels` labels used to create RouteAdvertisements for unmanaged no-overlay CUDNs. If omitted or empty, RouteAdvertisements are not created.
-37. selector label key - A Kubernetes label key under `frr_configuration_selector`.
-38. selector label value - A Kubernetes label value under `frr_configuration_selector`. Empty string values are supported.
-39. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+33. "name" - (Optional) Name of the primary UDN or CUDN. Defaults to `tft-primary`. TFT passes the name through to the generated UDN or CUDN and RouteAdvertisements resources; the user is responsible for choosing a value accepted by Kubernetes and OVN-Kubernetes.
+34. "mode" - (Optional) Field under `udn_primary_network`. Supported values are `udn` and `cudn`.
+35. "topology" - (Optional) Field under `udn_primary_network`. Supported values are `layer3` and `layer2`.
+36. "transport" - (Optional) Field under `udn_primary_network`. Supported values are `overlay` and `no-overlay`; `no-overlay` requires `mode: cudn` and `topology: layer3`.
+37. "uplink_name" - (Optional) Name of a pre-existing cluster-scoped `Uplink` for a primary CUDN. TFT references it in `CUDN.spec.uplinks` but does not create, modify, or delete it.
+38. "route_advertisement" - (Optional) RouteAdvertisements configuration for an unmanaged no-overlay primary CUDN. When specified, `frr_configuration_selector` is required and must not be empty.
+39. "targetVRF" - (Optional) Value copied to `RouteAdvertisements.spec.targetVRF`. TFT accepts any non-empty value, but it must be `auto`, `default`, or the name of a VRF configured on a router in the selected `FRRConfiguration`. If omitted, TFT omits the field and preserves the API's existing behavior.
+40. "frr_configuration_selector" - Required under `route_advertisement`. Map copied to `RouteAdvertisements.spec.frrConfigurationSelector.matchLabels` to select the base `FRRConfiguration`.
+41. selector label key - A Kubernetes label key under `frr_configuration_selector`.
+42. selector label value - A Kubernetes label value under `frr_configuration_selector`. Empty string values are supported.
+43. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
-40. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
+44. "dpu_node_host_label": (Required for DPU mode) The label on DPU nodes that identifies
   which host worker node they belong to. For NVIDIA DPUs, use `provisioning.dpu.nvidia.com/host`.
 
 
@@ -239,19 +247,26 @@ Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks
 
 The primary CIDR defaults to `15.1.0.0/16`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
 
-`udn_primary_network` supports `mode` values `udn` and `cudn`, `topology` values `layer3` and `layer2`, and `transport` values `overlay` and `no-overlay`. `no-overlay` requires `mode: cudn` and `topology: layer3`.
+`udn_primary_network` supports `mode` values `udn` and `cudn`, `topology` values `layer3` and `layer2`, and `transport` values `overlay` and `no-overlay`. Its `name` defaults to `tft-primary`. `no-overlay` requires `mode: cudn` and `topology: layer3`.
 
-`TFT_UDN_NO_OVERLAY_ROUTING_MANAGED` selects the CUDN's no-overlay routing mode. When it is true, OVN-Kubernetes manages routing and TFT does not create RouteAdvertisements. When it is false, routing is unmanaged; set `frr_configuration_selector` to have TFT create a RouteAdvertisements object, or leave the selector empty when routing is provisioned outside TFT. The selector is a map of `frrConfigurationSelector.matchLabels` labels.
+`TFT_UDN_NO_OVERLAY_ROUTING_MANAGED` selects the CUDN's no-overlay routing mode. When it is true, OVN-Kubernetes manages routing and `route_advertisement` must not be set. When it is false, routing is unmanaged; set `route_advertisement` to have TFT create a RouteAdvertisements object, or omit it when routing is provisioned outside TFT. Its required `frr_configuration_selector` map selects the base FRRConfigurations through `frrConfigurationSelector.matchLabels`. Its optional `targetVRF` is copied directly to `RouteAdvertisements.spec.targetVRF`; omitting it preserves the existing API behavior.
+
+Set `uplink_name` on a primary CUDN to add a pre-existing cluster-scoped `Uplink` to `CUDN.spec.uplinks`. The Uplink must exist before TFT applies the CUDN. TFT does not create, modify, or delete the Uplink.
 
 ```yaml
 udn_primary_network:
+  name: blue
   mode: cudn
   topology: layer3
   transport: no-overlay
-  frr_configuration_selector:
-    network: blue
-    ra.k8s.ovn.org/example: ""
+  uplink_name: blue-uplink
+  route_advertisement:
+    targetVRF: auto
+    frr_configuration_selector:
+      network: blue
 ```
+
+Set `udn_primary_network.name` to customize the generated CUDN name. OVN-Kubernetes uses the CUDN name for its VRF, so `name: blue` creates both `ClusterUserDefinedNetwork/blue` and VRF `blue`. With `targetVRF: auto`, the selected base `FRRConfiguration` must have a matching label such as `network: blue` and a BGP router configured with `vrf: blue`. The selector label only selects the `FRRConfiguration`; it does not set the VRF name. This exact name matching applies to CUDNs; namespaced UDNs use an OVN-Kubernetes-generated VRF name.
 
 ## Management Port Reachability Plugin
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,16 @@ tft:
     # "capabilities_pod": Linux capabilities for test pods. Format: {"add": ["CAP1", "CAP2"]}
     # capabilities_pod:
     #   add: ["NET_ADMIN", "SYS_TIME"]
+    # udn_primary_network:
+    #   name: blue
+    #   mode: cudn
+    #   topology: layer3
+    #   transport: no-overlay
+    #   uplink_name: blue-uplink
+    #   route_advertisement:
+    #     targetVRF: auto
+    #     frr_configuration_selector:
+    #       network: blue
     connections:
       - name: "Connection_1"
         # supported "type": iperf-tcp, iperf-udp, netperf-tcp-stream,

--- a/manifests/cudn.yaml.j2
+++ b/manifests/cudn.yaml.j2
@@ -10,6 +10,10 @@ metadata:
     k8s.v1.cni.cncf.io/resourceName: {{ resource_name }}
 {% endif %}
 spec:
+{% if has_uplink %}
+  uplinks:
+  - {{ uplink_name }}
+{% endif %}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name

--- a/manifests/udn-route-advertisements.yaml.j2
+++ b/manifests/udn-route-advertisements.yaml.j2
@@ -5,6 +5,9 @@ metadata:
   labels:
     tft-tests: "udn"
 spec:
+{% if has_target_vrf %}
+  targetVRF: {{ target_vrf }}
+{% endif %}
   advertisements:
   - PodNetwork
   frrConfigurationSelector:

--- a/testConfig.py
+++ b/testConfig.py
@@ -616,21 +616,68 @@ class ConfConnection(StructParseBaseNamed):
 
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
-class ConfUdnNetwork(StructParseBase):
-    mode: UdnNetworkMode
-    topology: UdnNetworkTopology
-    transport: Optional[UdnNetworkTransport]
+class ConfRouteAdvertisement(StructParseBase):
+    target_vrf: Optional[str]
     frr_configuration_selector: Mapping[str, str]
 
     def serialize(self) -> dict[str, Any]:
         data: dict[str, Any] = {
+            "frr_configuration_selector": dict(self.frr_configuration_selector),
+        }
+        if self.target_vrf is not None:
+            data["targetVRF"] = self.target_vrf
+        return data
+
+    @staticmethod
+    def parse(pctx: StructParseParseContext) -> "ConfRouteAdvertisement":
+        with pctx.with_strdict() as varg:
+            target_vrf = common.structparse_pop_str(
+                varg.for_key("targetVRF"),
+                default=None,
+                allow_empty=False,
+            )
+            frr_configuration_selector = common.structparse_pop_obj(
+                varg.for_key("frr_configuration_selector"),
+                construct=_construct_str_mapping,
+            )
+
+        if not frr_configuration_selector:
+            raise pctx.value_error(
+                "route_advertisement requires a non-empty "
+                "frr_configuration_selector",
+                key="frr_configuration_selector",
+            )
+
+        return ConfRouteAdvertisement(
+            yamlidx=pctx.yamlidx,
+            yamlpath=pctx.yamlpath,
+            target_vrf=target_vrf,
+            frr_configuration_selector=frr_configuration_selector,
+        )
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class ConfUdnNetwork(StructParseBase):
+    name: str
+    mode: UdnNetworkMode
+    topology: UdnNetworkTopology
+    transport: Optional[UdnNetworkTransport]
+    uplink_name: Optional[str]
+    route_advertisement: Optional[ConfRouteAdvertisement]
+
+    def serialize(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "name": self.name,
             "mode": self.mode.name,
             "topology": self.topology.name,
         }
         if self.transport is not None:
             data["transport"] = self.transport.name
-        if self.frr_configuration_selector:
-            data["frr_configuration_selector"] = dict(self.frr_configuration_selector)
+        if self.uplink_name is not None:
+            data["uplink_name"] = self.uplink_name
+        if self.route_advertisement is not None:
+            data["route_advertisement"] = self.route_advertisement.serialize()
         return data
 
     @staticmethod
@@ -639,18 +686,26 @@ class ConfUdnNetwork(StructParseBase):
         *,
         is_primary: bool,
     ) -> "ConfUdnNetwork":
+        default_name = "tft-primary"
         default_topology = (
             UdnNetworkTopology.LAYER3 if is_primary else UdnNetworkTopology.LAYER2
         )
 
         if pctx.arg is None:
+            name = default_name
             mode = UdnNetworkMode.UDN
             topology = default_topology
             transport: Optional[UdnNetworkTransport] = UdnNetworkTransport.OVERLAY
-            frr_configuration_selector: Mapping[str, str] = {}
+            uplink_name: Optional[str] = None
+            route_advertisement: Optional[ConfRouteAdvertisement] = None
         else:
             with pctx.with_strdict() as varg:
                 transport_configured = "transport" in varg.vdict
+                name = common.structparse_pop_str(
+                    varg.for_key("name"),
+                    default=default_name,
+                    allow_empty=False,
+                )
                 mode = common.structparse_pop_enum(
                     varg.for_key("mode"),
                     enum_type=UdnNetworkMode,
@@ -666,10 +721,15 @@ class ConfUdnNetwork(StructParseBase):
                     enum_type=UdnNetworkTransport,
                     default=None,
                 )
-                frr_configuration_selector = common.structparse_pop_obj(
-                    varg.for_key("frr_configuration_selector"),
-                    construct=_construct_str_mapping,
-                    default={},
+                uplink_name = common.structparse_pop_str(
+                    varg.for_key("uplink_name"),
+                    default=None,
+                    allow_empty=False,
+                )
+                route_advertisement = common.structparse_pop_obj(
+                    varg.for_key("route_advertisement"),
+                    construct=ConfRouteAdvertisement.parse,
+                    default=None,
                 )
             if transport is None and topology != UdnNetworkTopology.LOCALNET:
                 transport = UdnNetworkTransport.OVERLAY
@@ -701,19 +761,28 @@ class ConfUdnNetwork(StructParseBase):
                 "no-overlay transport is only supported for layer3 primary CUDN",
                 key="transport",
             )
-        if frr_configuration_selector and transport != UdnNetworkTransport.NO_OVERLAY:
+        if route_advertisement is not None and (
+            transport != UdnNetworkTransport.NO_OVERLAY
+        ):
             raise pctx.value_error(
-                "frr_configuration_selector requires transport no-overlay",
-                key="frr_configuration_selector",
+                "route_advertisement requires transport no-overlay",
+                key="route_advertisement",
+            )
+        if uplink_name is not None and (not is_primary or mode != UdnNetworkMode.CUDN):
+            raise pctx.value_error(
+                "uplink_name is only supported for a primary CUDN",
+                key="uplink_name",
             )
 
         return ConfUdnNetwork(
             yamlidx=pctx.yamlidx,
             yamlpath=pctx.yamlpath,
+            name=name,
             mode=mode,
             topology=topology,
             transport=transport,
-            frr_configuration_selector=frr_configuration_selector,
+            uplink_name=uplink_name,
+            route_advertisement=route_advertisement,
         )
 
 

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -430,7 +430,7 @@ tft:
     assert primary.mode == UdnNetworkMode.UDN
     assert primary.topology == UdnNetworkTopology.LAYER3
     assert primary.transport == UdnNetworkTransport.OVERLAY
-    assert primary.frr_configuration_selector == {}
+    assert primary.route_advertisement is None
 
     _check_testConfig(tc)
 
@@ -444,9 +444,11 @@ tft:
       mode: cudn
       topology: layer3
       transport: no-overlay
-      frr_configuration_selector:
-        network: blue
-        ra.k8s.ovn.org/example: ""
+      route_advertisement:
+        targetVRF: auto
+        frr_configuration_selector:
+          network: blue
+          ra.k8s.ovn.org/example: ""
     connections:
     - {}
 """)
@@ -459,7 +461,9 @@ tft:
     assert primary.mode == UdnNetworkMode.CUDN
     assert primary.topology == UdnNetworkTopology.LAYER3
     assert primary.transport == UdnNetworkTransport.NO_OVERLAY
-    assert primary.frr_configuration_selector == {
+    assert primary.route_advertisement is not None
+    assert primary.route_advertisement.target_vrf == "auto"
+    assert primary.route_advertisement.frr_configuration_selector == {
         "network": "blue",
         "ra.k8s.ovn.org/example": "",
     }

--- a/tftbase.py
+++ b/tftbase.py
@@ -260,7 +260,6 @@ def get_tft_pod_bringup_timeout() -> str:
 
 TFT_TESTS = "tft-tests"
 
-UDN_PRIMARY_NETWORK_NAME = "tft-primary"
 UDN_TRANSPORT_ACCEPTED_TIMEOUT = 120
 
 ENV_TFT_UDN_PRIMARY_CIDR = "TFT_UDN_PRIMARY_CIDR"

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -96,9 +96,10 @@ class TrafficFlowTests:
         network_name: str,
         network_label: str,
     ) -> None:
-        if not network.frr_configuration_selector:
+        route_advertisement = network.route_advertisement
+        if route_advertisement is None:
             logger.info(
-                "No no-overlay FRRConfiguration selector configured; "
+                "No no-overlay RouteAdvertisements configuration provided; "
                 f"not creating RouteAdvertisements for {network_name}"
             )
             return
@@ -114,9 +115,11 @@ class TrafficFlowTests:
             {
                 "network_name": _j(network_name),
                 "network_label": _j(network_label),
+                "has_target_vrf": route_advertisement.target_vrf is not None,
+                "target_vrf": _j(route_advertisement.target_vrf or ""),
                 "frr_configuration_selector": [
                     (_j(k), _j(v))
-                    for k, v in network.frr_configuration_selector.items()
+                    for k, v in route_advertisement.frr_configuration_selector.items()
                 ],
             },
             out_file=out_yaml,
@@ -158,6 +161,12 @@ class TrafficFlowTests:
                 else "Disabled"
             )
             no_overlay_routing = "Managed" if routing_managed else "Unmanaged"
+        if routing_managed and network.route_advertisement is not None:
+            raise RuntimeError(
+                "route_advertisement requires "
+                "TFT_UDN_NO_OVERLAY_ROUTING_MANAGED=false"
+            )
+        uplink_name = network.uplink_name or ""
         template_name = (
             "cudn.yaml.j2"
             if network.mode == tftbase.UdnNetworkMode.CUDN
@@ -184,6 +193,8 @@ class TrafficFlowTests:
                 "transport_name": transport_name,
                 "no_overlay_outbound_snat": _j(no_overlay_outbound_snat),
                 "no_overlay_routing": _j(no_overlay_routing),
+                "has_uplink": bool(uplink_name),
+                "uplink_name": _j(uplink_name),
             },
             out_file=out_yaml,
         )
@@ -256,7 +267,7 @@ class TrafficFlowTests:
                 udn_ns=udn_ns,
                 resource_name=resource_name,
                 network=tft.udn_primary_network,
-                network_name=tftbase.UDN_PRIMARY_NETWORK_NAME,
+                network_name=tft.udn_primary_network.name,
                 is_primary=True,
                 cidr=tftbase.get_udn_primary_cidr(),
             )
@@ -267,7 +278,8 @@ class TrafficFlowTests:
                 mode=network.mode,
                 topology=network.topology,
                 transport=network.transport,
-                frr_configuration_selector={},
+                uplink_name=None,
+                route_advertisement=None,
             )
             self._setup_udn_network(
                 cfg_descr,


### PR DESCRIPTION
## Summary

- Add optional `hostInterfaceName` configuration that creates an
  `OVSBridge` Uplink for the configured server and client nodes and
  references it from the primary CUDN.
- Group RouteAdvertisements settings under `route_advertisement`,
  requiring an FRRConfiguration selector and passing through an optional
  `targetVRF`.
- Make the primary UDN or CUDN name configurable while preserving
  `tft-primary` as the default. This allows `targetVRF: auto` to use a
  CUDN VRF matching the router in the selected FRRConfiguration.
- Clean up generated Uplinks with the other UDN resources and document
  the new configuration.

TFT only creates the Uplink resource. The host interface and backing OVS
bridge must already exist on every selected node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring primary UDN/CUDN names, uplinks, and route advertisements.
  * Added optional target VRF and FRR selection settings for route advertisements.
  * Updated generated manifests to include uplinks and target VRF settings when configured.
* **Documentation**
  * Clarified managed and unmanaged no-overlay routing behavior, RouteAdvertisements, FRR selection, and automatic VRF matching.
* **Bug Fixes**
  * Prevented incompatible route advertisement settings from being used with managed no-overlay routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->