### PR TITLE
Add TFT_EXTERNAL_SERVER to skip local podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_EXTERNAL_SERVER` address of a pre-existing external server in `host[:port]` format
      (e.g. `192.168.1.100:5201`). Works with any test type (iperf, netperf, http).
      When set and the connection mode is `EXTERNAL_IP` (`POD_TO_EXTERNAL`, `HOST_TO_EXTERNAL`,
-     `UDN_PRIMARY_POD_TO_EXTERNAL`, `POD_TO_EXTERNAL_EGRESS`), no local Podman container is
+     `UDN_PRIMARY_POD_TO_EXTERNAL`), no local Podman container is
      started; the client pod connects directly to the specified server. If port is omitted,
      the configured `pod_port` is used (defaults to `5201`). IPv6 addresses use bracket notation
      (e.g. `[fd00::1]:5201`). To start an iperf3 server on the remote host:

--- a/README.md
+++ b/README.md
@@ -488,6 +488,16 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK` physical network name for localnet CUDN tests. Defaults to `physnet`.
 - `TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED` outbound SNAT setting for no-overlay CUDNs. Defaults to `true`.
 - `TFT_UDN_NO_OVERLAY_ROUTING_MANAGED` whether OVN-Kubernetes manages routing for no-overlay CUDNs. Defaults to `false` (unmanaged).
+- `TFT_EXTERNAL_SERVER` address of a pre-existing external server in `host[:port]` format
+     (e.g. `192.168.1.100:5201`). Works with any test type (iperf, netperf, http).
+     When set and the connection mode is `EXTERNAL_IP` (`POD_TO_EXTERNAL`, `HOST_TO_EXTERNAL`,
+     `UDN_PRIMARY_POD_TO_EXTERNAL`, `POD_TO_EXTERNAL_EGRESS`), no local Podman container is
+     started; the client pod connects directly to the specified server. If port is omitted,
+     the configured `pod_port` is used (defaults to `5201`). IPv6 addresses use bracket notation
+     (e.g. `[fd00::1]:5201`). To start an iperf3 server on the remote host:
+     ```
+     podman run --rm -p 5201:5201 ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest iperf3 -s -p 5201
+     ```
 - `TFT_EXTERNAL_URL` URL to curl for external connectivity tests (e.g. `http://google.com`).
      Only effective when the connection type is `http` and the connection mode is `POD_TO_EXTERNAL`
      or `HOST_TO_EXTERNAL`. When set, no Podman server is started; the client pod curls this URL

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
      started; the client pod connects directly to the specified server. If port is omitted,
      the configured `pod_port` is used (defaults to `5201`). IPv6 addresses use bracket notation
      (e.g. `[fd00::1]:5201`). To start an iperf3 server on the remote host:
-     ```
+     ```bash
      podman run --rm -p 5201:5201 ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest iperf3 -s -p 5201
      ```
 - `TFT_EXTERNAL_URL` URL to curl for external connectivity tests (e.g. `http://google.com`).

--- a/task.py
+++ b/task.py
@@ -1298,6 +1298,7 @@ class ServerTask(Task, ABC):
         self.exec_persistent = ts.node_server.is_persistent_server
         self.pre_provisioning: bool = False
         self.port = port
+        self.port_base = port_base
         # external_port is discovered dynamically for EXTERNAL_IP mode
         self.external_port: int = 0
         self.pod_type = pod_type
@@ -1782,7 +1783,7 @@ class ClientTask(Task, ABC):
                 _, port = external_server
                 if port is not None:
                     return port
-                return self.server.port
+                return self.server.port_base
             return 0
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
             return self.server.external_port

--- a/task.py
+++ b/task.py
@@ -1269,6 +1269,13 @@ class ServerTask(Task, ABC):
             )
         )
 
+        if use_external and ts.connection.has_egress_ip:
+            raise ValueError(
+                "TFT_EXTERNAL_SERVER cannot be used with EgressIP tests"
+                " because the external server's output is not available"
+                " for source-IP verification"
+            )
+
         if use_external:
             in_file_template = ""
             pod_name = ""

--- a/task.py
+++ b/task.py
@@ -1261,13 +1261,15 @@ class ServerTask(Task, ABC):
         )
         port = port_base + self.index
 
-        use_internet = (
-            connection_mode == ConnectionMode.EXTERNAL_IP
-            and tftbase.get_tft_external_url() is not None
-            and ts.connection.test_type == TestType.HTTP
+        use_external = connection_mode == ConnectionMode.EXTERNAL_IP and (
+            tftbase.get_tft_external_server() is not None
+            or (
+                tftbase.get_tft_external_url() is not None
+                and ts.connection.test_type == TestType.HTTP
+            )
         )
 
-        if use_internet:
+        if use_external:
             in_file_template = ""
             pod_name = ""
         elif connection_mode == ConnectionMode.EXTERNAL_IP:
@@ -1300,7 +1302,7 @@ class ServerTask(Task, ABC):
         self.external_port: int = 0
         self.pod_type = pod_type
         self.connection_mode = ts.connection_mode
-        self.use_internet = use_internet
+        self.use_external = use_external
         self.in_file_template = in_file_template
         self.pod_name = pod_name
         self.server_stdout: Optional[str] = None
@@ -1338,8 +1340,7 @@ class ServerTask(Task, ABC):
         return self.cmd_line_args(for_template=True)
 
     def confirm_server_alive(self) -> None:
-        if self.use_internet:
-            # No server to wait for; client curls external URL directly.
+        if self.use_external:
             self.ts.event_server_alive.set()
             return
 
@@ -1468,8 +1469,7 @@ class ServerTask(Task, ABC):
 
         self.pre_provisioning = provisioning
 
-        if self.use_internet:
-            # No server needed; client curls external URL directly.
+        if self.use_external:
             self.ts.event_server_alive.set()
             return None
 
@@ -1704,8 +1704,10 @@ class ClientTask(Task, ABC):
         self.render_pod_file("Client Pod Yaml")
 
     def get_target_ip(self) -> str:
-        if self.server.use_internet:
-            # URL is used directly by testTypeHttp; no IP needed.
+        if self.server.use_external:
+            external_server = tftbase.get_tft_external_server()
+            if external_server is not None:
+                return external_server[0]
             return ""
         if self.connection_mode == ConnectionMode.CLUSTER_IP:
             if self.target_access_mode == TargetAccessMode.SERVICE_NAME:
@@ -1774,9 +1776,13 @@ class ClientTask(Task, ABC):
         return server_ip
 
     def get_target_port(self) -> int:
-        """Get the port to connect to. For EXTERNAL_IP, use discovered external_port."""
-        if self.server.use_internet:
-            # URL is used directly by testTypeHttp; no port needed.
+        if self.server.use_external:
+            external_server = tftbase.get_tft_external_server()
+            if external_server is not None:
+                _, port = external_server
+                if port is not None:
+                    return port
+                return self.server.port
             return 0
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
             return self.server.external_port

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -297,6 +297,46 @@ def test_udn_primary_cidr_list(monkeypatch: pytest.MonkeyPatch) -> None:
     tftbase.get_udn_primary_subnets.cache_clear()
 
 
+def test_get_tft_external_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.delenv(tftbase.ENV_TFT_EXTERNAL_SERVER, raising=False)
+    assert tftbase.get_tft_external_server() is None
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "")
+    assert tftbase.get_tft_external_server() is None
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "192.168.1.100")
+    assert tftbase.get_tft_external_server() == ("192.168.1.100", None)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "192.168.1.100:5201")
+    assert tftbase.get_tft_external_server() == ("192.168.1.100", 5201)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "myhost")
+    assert tftbase.get_tft_external_server() == ("myhost", None)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "myhost:12865")
+    assert tftbase.get_tft_external_server() == ("myhost", 12865)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "fd00::1")
+    assert tftbase.get_tft_external_server() == ("fd00::1", None)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "[fd00::1]:5201")
+    assert tftbase.get_tft_external_server() == ("fd00::1", 5201)
+
+    tftbase.get_tft_external_server.cache_clear()
+    monkeypatch.setenv(tftbase.ENV_TFT_EXTERNAL_SERVER, "[fd00::1]")
+    assert tftbase.get_tft_external_server() == ("fd00::1", None)
+
+    tftbase.get_tft_external_server.cache_clear()
+
+
 def test_str_sanitize() -> None:
     assert tftbase.str_sanitize("") == ""
     assert tftbase.str_sanitize("hello!wo_rld@12.3") == "hello-z21-wo-z5f-rld-z40-12-03"

--- a/tftbase.py
+++ b/tftbase.py
@@ -36,6 +36,7 @@ ENV_TFT_MANIFESTS_OVERRIDES = "TFT_MANIFESTS_OVERRIDES"
 ENV_TFT_MANIFESTS_YAMLS = "TFT_MANIFESTS_YAMLS"
 
 ENV_TFT_EXTERNAL_URL = "TFT_EXTERNAL_URL"
+ENV_TFT_EXTERNAL_SERVER = "TFT_EXTERNAL_SERVER"
 ENV_TFT_EXTERNAL_SERVER_STRING = "TFT_EXTERNAL_SERVER_STRING"
 
 ENV_TFT_HOST_NETWORK_NAMESPACE = "TFT_HOST_NETWORK_NAMESPACE"
@@ -242,6 +243,29 @@ def get_tft_external_url() -> Optional[str]:
     d = get_environ(ENV_TFT_EXTERNAL_URL)
     logger.info(f"env: {ENV_TFT_EXTERNAL_URL}={shlex.quote(d or '')}")
     return d or None
+
+
+@functools.cache
+def get_tft_external_server() -> Optional[tuple[str, Optional[int]]]:
+    d = get_environ(ENV_TFT_EXTERNAL_SERVER)
+    logger.info(f"env: {ENV_TFT_EXTERNAL_SERVER}={shlex.quote(d or '')}")
+    if not d:
+        return None
+    if d.startswith("["):
+        bracket_end = d.find("]")
+        if bracket_end == -1:
+            return (d, None)
+        host = d[1:bracket_end]
+        rest = d[bracket_end + 1 :]
+        if rest.startswith(":"):
+            return (host, int(rest[1:]))
+        return (host, None)
+    if d.count(":") == 1:
+        host, port_str = d.split(":", 1)
+        return (host, int(port_str))
+    if ":" in d:
+        return (d, None)
+    return (d, None)
 
 
 @functools.cache


### PR DESCRIPTION
Adds `TFT_EXTERNAL_SERVER` to skip local podman and use a pre-existing external server.

- [x] Feature
- [x] Documentation update
- [x] Unit test
- [x] Manually tested

Need this to be able to run from Prow, cc @wizhaoredhat 

Assisted-by: Claude 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an external test server through the `TFT_EXTERNAL_SERVER` environment variable.
  * Supports hostnames, IPv4 addresses, optional ports, and IPv6 address formats.
  * External tests can now connect to the configured server and port, with sensible port fallback behavior.

* **Documentation**
  * Documented supported address formats, defaults, applicable test modes, and a Podman setup example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->