### PR TITLE
Add primary UDN to CDN isolation test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ dpu_node_host_label: (40)
     | 77 | UDN_LAYER2_POD_TO_POD_DIFF_NODE |
     | 78 | CUDN_LOCALNET_POD_TO_POD_SAME_NODE |
     | 79 | CUDN_LOCALNET_POD_TO_POD_DIFF_NODE |
+    | 80 | UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE |
+    | 81 | UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE |
 4. "duration" - The duration that each individual test will run for.
 5. "pre_provision" - (Optional) Whether to pre-provision all pods and services once before the test run begins, rather than creating and tearing them down per test case. Defaults to false. Takes in "true/false".
 6. "name" - This is the connection name. Any string value to identify the connection.
@@ -223,7 +225,7 @@ dpu_node_host_label: (40)
 
 See the [OVN-Kubernetes UDN documentation](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/user-defined-networks.md) for details on User Defined Networks.
 
-Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically. NetworkPolicies and LoadBalancer services for UDN tests are also created in (and torn down from) the `{namespace}-udn` namespace.
+Test cases 37-47 and 70-81 use OVN-Kubernetes User Defined Networks. The framework creates and cleans up a `{namespace}-udn` namespace with the appropriate UDN CRDs automatically. NetworkPolicies and LoadBalancer services for UDN tests are also created in (and torn down from) the `{namespace}-udn` namespace.
 
 - **37-47** (Primary UDN): Network replacing the pod's default network. Its mode, topology, and transport are configured through `udn_primary_network`.
   - **37-42**: pod-to-pod, ClusterIP, and NodePort.
@@ -236,6 +238,9 @@ Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks
   - **74-75**: Layer2 CUDN.
   - **76-77**: Layer2 UDN.
   - **78-79**: Localnet CUDN.
+- **80-81** (Primary UDN isolation): Expected-block tests from a primary UDN pod to a cluster default network pod using direct pod IPs (same / different node).
+
+In the names of cases 80-81, `CDN` means cluster default network and is distinct from `CUDN`.
 
 The primary CIDR defaults to `15.1.0.0/16` with host subnet `24`. `TFT_UDN_PRIMARY_CIDR` accepts comma-separated entries, for example `15.1.0.0/17/24,15.1.128.0/17/24`. Each entry can include an optional host subnet length as `15.1.0.0/16/24`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
 

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -334,6 +334,16 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -670,3 +680,13 @@ IPERF_UDP:
       threshold: 5
     Reverse:
       threshold: 5
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0

--- a/task.py
+++ b/task.py
@@ -346,10 +346,14 @@ class Task(ABC):
         return "same-node" if self.ts.test_case_id.info.is_same_node else "diff-node"
 
     def get_namespace(self) -> str:
-        ns = self.ts.cfg_descr.get_tft().namespace
-        if self.ts.test_case_id.is_udn:
-            return tftbase.get_udn_namespace(ns)
-        return ns
+        return self.ts.test_case_id.info.get_namespace(
+            self.ts.cfg_descr.get_tft().namespace,
+            self.task_role,
+        )
+
+    @property
+    def uses_primary_udn(self) -> bool:
+        return self.ts.test_case_id.info.uses_primary_udn(self.task_role)
 
     def get_duration(self) -> int:
         conn_duration = self.ts.cfg_descr.get_connection().duration
@@ -416,9 +420,11 @@ class Task(ABC):
         tft = self.ts.cfg_descr.get_tft()
         if not tft.pre_provision:
             return False
-        is_udn = self.ts.test_case_id.is_udn
+        namespace = self.get_namespace()
+        base_namespace = tft.namespace
         return any(
-            tc.info.uses_secondary_network_pod and tc.is_udn == is_udn
+            tc.info.uses_secondary_network_pod
+            and tc.info.get_namespace(base_namespace, self.task_role) == namespace
             for tc in tft.test_cases
         )
 
@@ -448,7 +454,11 @@ class Task(ABC):
         cases, so it receives each unique test-defined NAD in the UDN namespace.
         Other pods receive only their effective NAD, or none.
         """
-        if self.ts.test_case_id.is_udn and self._shares_pre_provisioned_secondary_pod():
+        if (
+            self.get_namespace()
+            == tftbase.get_udn_namespace(self.ts.cfg_descr.get_tft().namespace)
+            and self._shares_pre_provisioned_secondary_pod()
+        ):
             namespace = self.get_namespace()
             return tuple(
                 dict.fromkeys(
@@ -477,7 +487,7 @@ class Task(ABC):
         UDN VF when primary and secondary tests share the UDN namespace.
         """
         if self.pod_type == PodType.SRIOV:
-            return str(1 + int(self.ts.test_case_id.is_udn_primary))
+            return str(1 + int(self.uses_primary_udn))
         needs_primary_udn_vf = self.ts.test_case_id.is_udn_secondary and any(
             test_case.is_udn_primary
             for test_case in self.ts.cfg_descr.get_tft().test_cases
@@ -697,7 +707,7 @@ class Task(ABC):
         try:
             if y:
                 pod_ip = y["status"]["podIP"]
-                if self.ts.test_case_id.is_udn_primary:
+                if self.uses_primary_udn:
                     pod_networks_str = y["metadata"]["annotations"].get(
                         "k8s.ovn.org/pod-networks", ""
                     )

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -140,10 +140,10 @@ class HttpClient(task.ClientTask):
             if test_metadata.expects_blocked:
                 if success:
                     success = False
-                    msg = "Traffic was not blocked as expected (policy not enforced)"
+                    msg = "Traffic was not blocked as expected"
                 else:
                     success = True
-                    msg = "Traffic was blocked as expected (deny policy active)"
+                    msg = "Traffic was blocked as expected"
 
             return FlowTestOutput(
                 success=success,

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -233,7 +233,7 @@ class IperfClient(task.ClientTask):
                     msg = f"Expected traffic to be blocked but got throughput {bitrate_gbps}"
                 else:
                     success = True
-                    msg = "Traffic was blocked as expected (deny policy active)"
+                    msg = "Traffic was blocked as expected"
 
             return FlowTestOutput(
                 success=success,

--- a/tests/eval-config-2.yaml
+++ b/tests/eval-config-2.yaml
@@ -334,6 +334,16 @@ IPERF_TCP:
   Reverse:
     threshold: 10
   id: 79
+- Normal:
+    threshold: 0
+  Reverse:
+    threshold: 0
+  id: 80
+- Normal:
+    threshold: 0
+  Reverse:
+    threshold: 0
+  id: 81
 IPERF_UDP:
 - Normal:
     threshold: 5
@@ -670,3 +680,13 @@ IPERF_UDP:
   Reverse:
     threshold: 5
   id: 79
+- Normal:
+    threshold: 0
+  Reverse:
+    threshold: 0
+  id: 80
+- Normal:
+    threshold: 0
+  Reverse:
+    threshold: 0
+  id: 81

--- a/tests/generate-eval-config-output0.yaml
+++ b/tests/generate-eval-config-output0.yaml
@@ -334,6 +334,16 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -670,3 +680,13 @@ IPERF_UDP:
       threshold: 5
     Reverse:
       threshold: 5
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0

--- a/tests/generate-eval-config-output2.yaml
+++ b/tests/generate-eval-config-output2.yaml
@@ -377,6 +377,16 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -713,3 +723,13 @@ IPERF_UDP:
       threshold: 5
     Reverse:
       threshold: 5
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0

--- a/tests/generate-eval-config-output3.yaml
+++ b/tests/generate-eval-config-output3.yaml
@@ -355,6 +355,16 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
 IPERF_UDP:
   - id: POD_TO_POD_SAME_NODE
     Normal:
@@ -691,3 +701,13 @@ IPERF_UDP:
       threshold: 5
     Reverse:
       threshold: 5
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0
+  - id: UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    Normal:
+      threshold: 0
+    Reverse:
+      threshold: 0

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -487,3 +487,23 @@ tft:
             full_config=full_config,
             kubeconfigs=testConfigKubeconfigsArgs1,
         )
+
+
+def test_primary_udn_to_cdn_config() -> None:
+    full_config = yaml.safe_load("""
+tft:
+  - test_cases:
+      - UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE
+      - UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE
+    connections:
+    - type: iperf-tcp
+""")
+    tc = testConfig.TestConfig(
+        full_config=full_config,
+        kubeconfigs=testConfigKubeconfigsArgs1,
+    )
+
+    assert tc.config.tft[0].test_cases == (
+        TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE,
+        TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE,
+    )

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -129,8 +129,8 @@ def test_test_case_typ_infos() -> None:
         assert ti.test_case_type is typ
         assert typ.info is ti
 
-    assert list(TestCaseType)[-1].value == 79
-    expected_values = [*range(1, 48), *range(60, 80)]
+    assert list(TestCaseType)[-1].value == 81
+    expected_values = [*range(1, 48), *range(60, 82)]
     assert expected_values == [typ.value for typ in tftbase.TestCaseType]
 
     for typ in TestCaseType:
@@ -224,6 +224,26 @@ def test_secondary_udn_test_case_info() -> None:
 
     networks = tuple(network for _, _, network in expected)
     assert len({network.name for network in networks}) == len(networks)
+
+
+def test_primary_udn_to_cdn_test_case_info() -> None:
+    cases = (
+        (
+            TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE,
+            True,
+        ),
+        (
+            TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE,
+            False,
+        ),
+    )
+
+    for test_case, is_same_node in cases:
+        info = test_case.info
+        assert info.connection_mode == ConnectionMode.POD_IP
+        assert info.is_same_node is is_same_node
+        assert info.expects_blocked is True
+        assert test_case.is_udn_primary
 
 
 def test_anp_test_case_info() -> None:

--- a/tftbase.py
+++ b/tftbase.py
@@ -680,6 +680,8 @@ class TestCaseType(Enum):
     UDN_LAYER2_POD_TO_POD_DIFF_NODE = 77
     CUDN_LOCALNET_POD_TO_POD_SAME_NODE = 78
     CUDN_LOCALNET_POD_TO_POD_DIFF_NODE = 79
+    UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE = 80
+    UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE = 81
 
     @property
     def is_egress_ip(self) -> bool:
@@ -705,6 +707,10 @@ class TestCaseType(Enum):
     @property
     def udn_network_spec(self) -> Optional[UDNSecondaryNetworkSpec]:
         return self.info.udn_network_spec
+
+    @property
+    def uses_base_namespace(self) -> bool:
+        return self.info.uses_base_namespace
 
     @property
     def info(self) -> "TestCaseTypInfo":
@@ -1223,6 +1229,7 @@ class TestCaseTypInfo:
     is_client_hostbacked: bool
     expects_blocked: bool = False
     udn_network_spec: Optional[UDNSecondaryNetworkSpec] = None
+    server_uses_default_network: bool = False
 
     @property
     def node_location(self) -> str:
@@ -1237,6 +1244,27 @@ class TestCaseTypInfo:
             or self.test_case_type.is_udn_secondary
             or self.test_case_type.is_udn_localnet
         )
+
+    @property
+    def uses_base_namespace(self) -> bool:
+        return not self.test_case_type.is_udn or self.server_uses_default_network
+
+    def uses_primary_udn(self, task_role: TaskRole) -> bool:
+        if task_role == TaskRole.CLIENT:
+            return self.test_case_type.is_udn_primary
+        if task_role == TaskRole.SERVER:
+            return (
+                self.test_case_type.is_udn_primary
+                and not self.server_uses_default_network
+            )
+        raise ValueError(f"Invalid task role {task_role}")
+
+    def get_namespace(self, base_namespace: str, task_role: TaskRole) -> str:
+        if self.uses_primary_udn(task_role):
+            return get_udn_namespace(base_namespace)
+        if self.test_case_type.is_udn_secondary:
+            return get_udn_namespace(base_namespace)
+        return base_namespace
 
     def get_server_pod_type(self, pod_type: PodType) -> PodType:
         if self.is_server_hostbacked:
@@ -1743,6 +1771,24 @@ _test_case_typ_infos = {
             is_server_hostbacked=False,
             is_client_hostbacked=False,
             udn_network_spec=CUDN_SECONDARY_LOCALNET_NETWORK,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_SAME_NODE,
+            connection_mode=ConnectionMode.POD_IP,
+            is_same_node=True,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+            expects_blocked=True,
+            server_uses_default_network=True,
+        ),
+        TestCaseTypInfo(
+            test_case_type=TestCaseType.UDN_PRIMARY_POD_TO_CDN_POD_DIFF_NODE,
+            connection_mode=ConnectionMode.POD_IP,
+            is_same_node=False,
+            is_server_hostbacked=False,
+            is_client_hostbacked=False,
+            expects_blocked=True,
+            server_uses_default_network=True,
         ),
     )
 }

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -32,8 +32,8 @@ class TrafficFlowTests:
         self._udn_ns_created: bool = False
         self._udn_setup_done: bool = False
 
-    def _has_non_udn_tests(self, cfg_descr: ConfigDescriptor) -> bool:
-        return any(not tc.is_udn for tc in cfg_descr.get_tft().test_cases)
+    def _uses_base_namespace(self, cfg_descr: ConfigDescriptor) -> bool:
+        return any(tc.uses_base_namespace for tc in cfg_descr.get_tft().test_cases)
 
     def _configure_namespace(
         self, cfg_descr: ConfigDescriptor, *, namespace: str | None = None
@@ -287,7 +287,7 @@ class TrafficFlowTests:
 
     def _setup_secondary_nad(self, cfg_descr: ConfigDescriptor) -> None:
         tft = cfg_descr.get_tft()
-        if not self._has_non_udn_tests(cfg_descr):
+        if not self._uses_base_namespace(cfg_descr):
             return
         if not any(
             not tc.is_udn
@@ -716,7 +716,7 @@ class TrafficFlowTests:
     ) -> TftResults:
         test = cfg_descr.get_tft()
         ns_created = False
-        if self._has_non_udn_tests(cfg_descr):
+        if self._uses_base_namespace(cfg_descr):
             ns_created = self._configure_namespace(cfg_descr)
         self._cleanup_stale_udn(cfg_descr)
         self._cleanup_previous_testspace(cfg_descr, force_cleanup=True)


### PR DESCRIPTION
Add same-node and different-node pod IP cases that verify traffic from a primary UDN pod to a cluster default network pod is blocked.

Place each endpoint in the correct namespace and scope primary UDN IP selection, SR-IOV resources, and pre-provisioned pod sharing to the endpoint network. Update evaluator configs, fixtures, tests, and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added same-node and cross-node test coverage for traffic between primary UDN pods and CDN pods.
  * Added TCP and UDP evaluation entries for the new connectivity scenarios.

* **Bug Fixes**
  * Improved namespace and network selection for primary UDN and default-network traffic tests.
  * Clarified blocked and allowed traffic result messages.

* **Documentation**
  * Updated test-case documentation and terminology through cases 80–81.

* **Tests**
  * Added configuration parsing and validation tests for the new scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->