### PR TITLE
Log test commands with task results

### DIFF
--- a/task.py
+++ b/task.py
@@ -1157,6 +1157,7 @@ class Task(ABC):
                 log_level = logging.ERROR
                 log_msg = "failure"
             logger.log(log_level, f"Results of {self.ts.get_test_str()}: {log_msg}")
+            logger.log(log_level, f"Command: {result.command}")
             logger.debug(f"result: {common.dataclass_to_json(result)}")
         elif isinstance(result, PluginOutput):
             tft_result_builder.add_plugin(result)


### PR DESCRIPTION
We already run the server command, so we should also mimic the same with the client. This will also help with quick debugging perf failures because currently we only emit the command ran for the client if there is a connection failure not a throughput failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Task output now includes the executed command alongside the result status for flow test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->