### PR TITLE
Include pod names in traffic flow test logs

### DIFF
--- a/testSettings.py
+++ b/testSettings.py
@@ -138,11 +138,13 @@ class TestSettings:
     def connection_mode(self) -> tftbase.ConnectionMode:
         return self.test_case_id.info.connection_mode
 
-    def get_test_info(self) -> str:
+    def get_test_info(self, *, client_pod_name: str, server_pod_name: str) -> str:
         return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.test_case_id.info.node_location}, target-access={self.target_access_mode.name}
+        Client Pod: {client_pod_name}
         Client Node: {self.node_client.name}
             Tenant={self.client_is_tenant}
             Index={self.client_index}
+        Server Pod: {server_pod_name}
         Server Node: {self.node_server.name}
             Exec Persistence: {self.node_server.is_persistent_server}
             Tenant={self.server_is_tenant}

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -588,8 +588,10 @@ class TrafficFlowTests:
             reverse=reverse,
             target_access_mode=target_access_mode,
         )
-        logger.info(f"Starting test {ts.get_test_info()}")
         s, c = connection.test_type_handler.create_server_client(ts)
+        logger.info(
+            f"Starting test {ts.get_test_info(client_pod_name=c.pod_name, server_pod_name=s.pod_name)}"
+        )
         servers.append(s)
         clients.append(c)
         current_test_case = cfg_descr.get_test_case()


### PR DESCRIPTION
We already emit the node names, so updating to also emit the pod names to help with debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Test startup messages now identify both the client and server environments involved.
  * Test information output includes the names of the participating pods for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->