### PR TITLE
Preserve UDN namespace during resource cleanup

### DIFF
--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -446,10 +446,8 @@ class TrafficFlowTests:
         if client.oc_get(f"namespace/{udn_ns}", may_fail=True) is None:
             self._cleanup_udn_resources(cfg_descr, None, delete_namespace=False)
             return
-        logger.info(
-            f"Found existing UDN namespace {udn_ns} from a previous run, cleaning up"
-        )
-        self._cleanup_udn_resources(cfg_descr, udn_ns, delete_namespace=True)
+        logger.info(f"Found existing UDN namespace {udn_ns}, cleaning up TFT resources")
+        self._cleanup_udn_resources(cfg_descr, udn_ns, delete_namespace=False)
 
     def _cleanup_previous_testspace(
         self, cfg_descr: ConfigDescriptor, force_cleanup: bool = False


### PR DESCRIPTION
With the regular namespace, it is not deleted at the beginning of the run, it just cleans up resources in them. We should mimic the same behavior with {ns}-udn as well, because currently it tried to delete the udn ns at the beginning of the run if it already exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale resource cleanup by removing TFT-labeled resources while preserving the existing namespace.
  * Updated cleanup logging to provide clearer, more accurate messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->