### PR TITLE
Add configurable IPAM modes for secondary UDNs and CUDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Test cases 37-47 and 70-79 run traffic over OVN-Kubernetes User Defined Networks
 
 The primary CIDR defaults to `15.1.0.0/16` with host subnet `24`. `TFT_UDN_PRIMARY_CIDR` accepts comma-separated entries, for example `15.1.0.0/17/24,15.1.128.0/17/24`. Each entry can include an optional host subnet length as `15.1.0.0/16/24`. Secondary CIDRs default to `15.2.0.0/16` (Layer3 CUDN), `15.3.0.0/16` (Layer3 UDN), `15.4.0.0/16` (Layer2 CUDN), `15.5.0.0/16` (Layer2 UDN), and `15.6.0.0/24` (localnet CUDN). Each CIDR has a corresponding environment variable listed below. The localnet physical network name defaults to `physnet`, overridable via `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK`. Reference manifests are in `manifests/udn.yaml.j2` and `manifests/cudn.yaml.j2`.
 
+Secondary Layer2 and Localnet IPAM modes can be passed through with the corresponding environment variables listed below. TFT does not validate their values. When a variable is unset, TFT omits `ipam` from that UDN/CUDN. TFT includes `subnets` only when the mode is unset or `Enabled`, as required by the OVN-Kubernetes API.
+
 `udn_primary_network` supports `mode` values `udn` and `cudn`, `topology` values `layer3` and `layer2`, and `transport` values `overlay` and `no-overlay`. `no-overlay` requires `mode: cudn` and `topology: layer3`.
 
 `TFT_UDN_NO_OVERLAY_ROUTING_MANAGED` selects the CUDN's no-overlay routing mode. When it is true, OVN-Kubernetes manages routing and TFT does not create RouteAdvertisements. When it is false, routing is unmanaged; set `frr_configuration_selector` to have TFT create a RouteAdvertisements object, or leave the selector empty when routing is provisioned outside TFT. The selector is a map of `frrConfigurationSelector.matchLabels` labels.
@@ -485,6 +487,9 @@ match. The `EgressIP` resource and the egress node's labels are removed during c
 - `TFT_CUDN_SECONDARY_LAYER2_CIDR` CIDR for secondary Layer2 CUDN tests. Defaults to `15.4.0.0/16`.
 - `TFT_UDN_SECONDARY_LAYER2_CIDR` CIDR for secondary Layer2 UDN tests. Defaults to `15.5.0.0/16`.
 - `TFT_CUDN_SECONDARY_LOCALNET_CIDR` CIDR for secondary localnet CUDN tests. Defaults to `15.6.0.0/24`.
+- `TFT_CUDN_SECONDARY_LAYER2_IPAM_MODE` `ipam.mode` for secondary Layer2 CUDN tests. Omitted when unset.
+- `TFT_UDN_SECONDARY_LAYER2_IPAM_MODE` `ipam.mode` for secondary Layer2 UDN tests. Omitted when unset.
+- `TFT_CUDN_SECONDARY_LOCALNET_IPAM_MODE` `ipam.mode` for secondary Localnet CUDN tests. Omitted when unset.
 - `TFT_CUDN_LOCALNET_PHYSICAL_NETWORK` physical network name for localnet CUDN tests. Defaults to `physnet`.
 - `TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED` outbound SNAT setting for no-overlay CUDNs. Defaults to `true`.
 - `TFT_UDN_NO_OVERLAY_ROUTING_MANAGED` whether OVN-Kubernetes manages routing for no-overlay CUDNs. Defaults to `false` (unmanaged).

--- a/manifests/cudn.yaml.j2
+++ b/manifests/cudn.yaml.j2
@@ -29,18 +29,30 @@ spec:
 {% elif topology_name == "Layer2" %}
     layer2:
       role: {{ network_type }}
+{% if has_subnets %}
       subnets:
 {% for subnet in subnets %}
       - {{ subnet.cidr }}
 {% endfor %}
+{% endif %}
+{% if has_ipam_mode %}
+      ipam:
+        mode: {{ ipam_mode }}
+{% endif %}
 {% elif topology_name == "Localnet" %}
     localnet:
       role: {{ network_type }}
       physicalNetworkName: {{ physical_network_name }}
+{% if has_subnets %}
       subnets:
 {% for subnet in subnets %}
       - {{ subnet.cidr }}
 {% endfor %}
+{% endif %}
+{% if has_ipam_mode %}
+      ipam:
+        mode: {{ ipam_mode }}
+{% endif %}
 {% endif %}
 {% if transport_name == "NoOverlay" %}
     transport: NoOverlay

--- a/manifests/udn.yaml.j2
+++ b/manifests/udn.yaml.j2
@@ -23,8 +23,14 @@ spec:
 {% elif topology_name == "Layer2" %}
   layer2:
     role: {{ network_type }}
+{% if has_subnets %}
     subnets:
 {% for subnet in subnets %}
     - {{ subnet.cidr }}
 {% endfor %}
+{% endif %}
+{% if has_ipam_mode %}
+    ipam:
+      mode: {{ ipam_mode }}
+{% endif %}
 {% endif %}

--- a/tftbase.py
+++ b/tftbase.py
@@ -269,6 +269,9 @@ ENV_TFT_UDN_SECONDARY_LAYER3_CIDR = "TFT_UDN_SECONDARY_LAYER3_CIDR"
 ENV_TFT_CUDN_SECONDARY_LAYER2_CIDR = "TFT_CUDN_SECONDARY_LAYER2_CIDR"
 ENV_TFT_UDN_SECONDARY_LAYER2_CIDR = "TFT_UDN_SECONDARY_LAYER2_CIDR"
 ENV_TFT_CUDN_SECONDARY_LOCALNET_CIDR = "TFT_CUDN_SECONDARY_LOCALNET_CIDR"
+ENV_TFT_CUDN_SECONDARY_LAYER2_IPAM_MODE = "TFT_CUDN_SECONDARY_LAYER2_IPAM_MODE"
+ENV_TFT_UDN_SECONDARY_LAYER2_IPAM_MODE = "TFT_UDN_SECONDARY_LAYER2_IPAM_MODE"
+ENV_TFT_CUDN_SECONDARY_LOCALNET_IPAM_MODE = "TFT_CUDN_SECONDARY_LOCALNET_IPAM_MODE"
 ENV_TFT_CUDN_LOCALNET_PHYSICAL_NETWORK = "TFT_CUDN_LOCALNET_PHYSICAL_NETWORK"
 ENV_TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED = (
     "TFT_UDN_NO_OVERLAY_OUTBOUND_SNAT_ENABLED"
@@ -330,6 +333,28 @@ def get_cudn_secondary_localnet_cidr() -> str:
     s = get_environ(ENV_TFT_CUDN_SECONDARY_LOCALNET_CIDR) or "15.6.0.0/24"
     logger.info(f"env: {ENV_TFT_CUDN_SECONDARY_LOCALNET_CIDR}={shlex.quote(s)}")
     return s
+
+
+def _get_udn_ipam_mode(name: str) -> Optional[str]:
+    mode = get_environ(name)
+    if mode is not None:
+        logger.info(f"env: {name}={shlex.quote(mode)}")
+    return mode
+
+
+@functools.cache
+def get_cudn_secondary_layer2_ipam_mode() -> Optional[str]:
+    return _get_udn_ipam_mode(ENV_TFT_CUDN_SECONDARY_LAYER2_IPAM_MODE)
+
+
+@functools.cache
+def get_udn_secondary_layer2_ipam_mode() -> Optional[str]:
+    return _get_udn_ipam_mode(ENV_TFT_UDN_SECONDARY_LAYER2_IPAM_MODE)
+
+
+@functools.cache
+def get_cudn_secondary_localnet_ipam_mode() -> Optional[str]:
+    return _get_udn_ipam_mode(ENV_TFT_CUDN_SECONDARY_LOCALNET_IPAM_MODE)
 
 
 def get_udn_namespace(base_namespace: str) -> str:
@@ -573,6 +598,7 @@ class UDNSecondaryNetworkSpec:
     topology: UdnNetworkTopology
     transport: Optional[UdnNetworkTransport]
     get_cidr: typing.Callable[[], str]
+    get_ipam_mode: Optional[typing.Callable[[], Optional[str]]] = None
 
 
 CUDN_SECONDARY_LAYER3_NETWORK = UDNSecondaryNetworkSpec(
@@ -595,6 +621,7 @@ CUDN_SECONDARY_LAYER2_NETWORK = UDNSecondaryNetworkSpec(
     topology=UdnNetworkTopology.LAYER2,
     transport=UdnNetworkTransport.OVERLAY,
     get_cidr=get_cudn_secondary_layer2_cidr,
+    get_ipam_mode=get_cudn_secondary_layer2_ipam_mode,
 )
 UDN_SECONDARY_LAYER2_NETWORK = UDNSecondaryNetworkSpec(
     name="tft-udn-layer2",
@@ -602,6 +629,7 @@ UDN_SECONDARY_LAYER2_NETWORK = UDNSecondaryNetworkSpec(
     topology=UdnNetworkTopology.LAYER2,
     transport=UdnNetworkTransport.OVERLAY,
     get_cidr=get_udn_secondary_layer2_cidr,
+    get_ipam_mode=get_udn_secondary_layer2_ipam_mode,
 )
 CUDN_SECONDARY_LOCALNET_NETWORK = UDNSecondaryNetworkSpec(
     name="tft-cudn-localnet",
@@ -609,6 +637,7 @@ CUDN_SECONDARY_LOCALNET_NETWORK = UDNSecondaryNetworkSpec(
     topology=UdnNetworkTopology.LOCALNET,
     transport=None,
     get_cidr=get_cudn_secondary_localnet_cidr,
+    get_ipam_mode=get_cudn_secondary_localnet_ipam_mode,
 )
 
 

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -137,6 +137,7 @@ class TrafficFlowTests:
         network_name: str,
         is_primary: bool,
         subnets: tuple[tuple[str, int], ...],
+        ipam_mode: str | None,
     ) -> None:
         client = cfg_descr.tc.client_tenant
         network_label = network_name
@@ -179,6 +180,9 @@ class TrafficFlowTests:
                 "topology": _j(topology_name),
                 "topology_name": topology_name,
                 "network_type": _j("Primary" if is_primary else "Secondary"),
+                "has_ipam_mode": ipam_mode is not None,
+                "ipam_mode": _j(ipam_mode or ""),
+                "has_subnets": ipam_mode in (None, "Enabled"),
                 "subnets": [
                     {"cidr": _j(cidr), "host_subnet": host_subnet}
                     for cidr, host_subnet in subnets
@@ -262,6 +266,7 @@ class TrafficFlowTests:
                 network_name=tftbase.UDN_PRIMARY_NETWORK_NAME,
                 is_primary=True,
                 subnets=tftbase.get_udn_primary_subnets(),
+                ipam_mode=None,
             )
 
         for network in secondary_networks.values():
@@ -280,6 +285,11 @@ class TrafficFlowTests:
                 network_name=network.name,
                 is_primary=False,
                 subnets=((network.get_cidr(), tftbase.UDN_DEFAULT_HOST_SUBNET),),
+                ipam_mode=(
+                    network.get_ipam_mode()
+                    if network.get_ipam_mode is not None
+                    else None
+                ),
             )
 
         self._configure_namespace(cfg_descr, namespace=udn_ns)


### PR DESCRIPTION
Pass configured IPAM modes through to secondary Layer2 UDN and CUDN manifests and secondary localnet CUDNs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable IPAM modes for secondary Layer2 and Localnet UDN/CUDN test networks.
  * Network manifests now include `ipam.mode` and subnet settings when configured, while omitting IPAM settings when unset.
  * Added environment-variable configuration options for selecting IPAM modes.

* **Documentation**
  * Documented the new configuration options and clarified that values are passed through without validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->